### PR TITLE
Replace org chart with table-based profile appender

### DIFF
--- a/graph-api.js
+++ b/graph-api.js
@@ -1,796 +1,461 @@
-// Microsoft Graph API Integration
+// Microsoft Graph API integration for profile enrichment
 const GraphAPI = (function() {
   'use strict';
-  
-  // Private variables
-  let accessToken = '';
-  let startingEmail = '';
-  let maxUsers = 100;
-  let licensedEmails = new Set(); // Stores full email addresses from CSV
-  let licensedUsernames = new Set(); // Stores email usernames for matching
-  let aiEngagementMap = new Map(); // Map of email usernames to daily messages
-  let orgData = [];
-  let filteredOrgData = [];
-  let hierarchyData = null;
-  let filterNoDepartment = true; // Default to filtering out users with no department
-  let filterInterns = true; // Default to filtering out interns
-  let filterNoTitle = true; // Default to filtering out users with no title
-  
-  // API configuration
+
   const graphBaseUrl = 'https://graph.microsoft.com/v1.0';
-  const orgDomain = 'tcco.com';
-  
-  // Public API
-  return {
-    // Initialize the module
-    initialize: function() {
-      // Set up event listeners for CSV upload
-      const csvInput = document.getElementById('csvFile');
-      if (csvInput) {
-        csvInput.addEventListener('change', this.handleCsvUpload.bind(this));
-      }
-      
-      // Set up department filter checkbox listener
-      const filterCheckbox = document.getElementById('filterNoDept');
-      if (filterCheckbox) {
-        filterCheckbox.checked = filterNoDepartment; // Set default state
-        filterCheckbox.addEventListener('change', this.handleFilterChange.bind(this));
-      }
-      
-      // Set up interns filter checkbox listener
-      const filterInternsCheckbox = document.getElementById('filterInterns');
-      if (filterInternsCheckbox) {
-        filterInternsCheckbox.checked = filterInterns; // Set default state
-        filterInternsCheckbox.addEventListener('change', this.handleFilterChange.bind(this));
-      }
+  const fieldDefinitions = [
+    { key: 'displayName', label: 'Display Name' },
+    { key: 'jobTitle', label: 'Job Title' },
+    { key: 'department', label: 'Department' },
+    { key: 'officeLocation', label: 'Office Location' },
+    { key: 'companyName', label: 'Company Name' },
+    { key: 'mail', label: 'Mail' },
+    { key: 'userPrincipalName', label: 'User Principal Name' },
+    { key: 'businessPhones', label: 'Business Phones' },
+    { key: 'mobilePhone', label: 'Mobile Phone' },
+    { key: 'preferredLanguage', label: 'Preferred Language' },
+    { key: 'givenName', label: 'Given Name' },
+    { key: 'surname', label: 'Surname' }
+  ];
 
-      // Set up title filter checkbox listener
-      const filterNoTitleCheckbox = document.getElementById('filterNoTitle');
-      if (filterNoTitleCheckbox) {
-        filterNoTitleCheckbox.checked = filterNoTitle; // Set default state
-        filterNoTitleCheckbox.addEventListener('change', this.handleFilterChange.bind(this));
-      }
-      
-      // Load email history from localStorage
-      this.loadEmailHistory();
-    },
-    
-    // Load email history from localStorage
-    loadEmailHistory: function() {
-      try {
-        const history = localStorage.getItem('orgChartEmailHistory');
-        if (history) {
-          const emails = JSON.parse(history);
-          const datalist = document.getElementById('emailHistory');
-          if (datalist) {
-            datalist.innerHTML = '';
-            // Add up to 10 most recent emails
-            emails.slice(0, 10).forEach(email => {
-              const option = document.createElement('option');
-              option.value = email;
-              datalist.appendChild(option);
-            });
-          }
-        }
-      } catch (error) {
-        console.error('Error loading email history:', error);
-      }
-    },
-    
-    // Save email to history
-    saveEmailToHistory: function(email) {
-      try {
-        let history = [];
-        const stored = localStorage.getItem('orgChartEmailHistory');
-        if (stored) {
-          history = JSON.parse(stored);
-        }
-        
-        // Remove email if it already exists (to move it to front)
-        history = history.filter(e => e !== email);
-        
-        // Add email to beginning
-        history.unshift(email);
-        
-        // Keep only last 10 emails
-        history = history.slice(0, 10);
-        
-        // Save to localStorage
-        localStorage.setItem('orgChartEmailHistory', JSON.stringify(history));
-        
-        // Reload the datalist
-        this.loadEmailHistory();
-      } catch (error) {
-        console.error('Error saving email to history:', error);
-      }
-    },
-    
-    // Clear email history
-    clearEmailHistory: function() {
-      if (confirm('Clear all saved email addresses?')) {
-        try {
-          localStorage.removeItem('orgChartEmailHistory');
-          const datalist = document.getElementById('emailHistory');
-          if (datalist) {
-            datalist.innerHTML = '';
-          }
-          // Also clear the current input
-          const input = document.getElementById('startingEmail');
-          if (input) {
-            input.value = '';
-          }
-        } catch (error) {
-          console.error('Error clearing email history:', error);
-        }
-      }
-    },
-    
-    // Handle department filter change
-    handleFilterChange: function(event) {
-      // Update the appropriate filter based on which checkbox changed
-      if (event.target.id === 'filterNoDept') {
-        filterNoDepartment = event.target.checked;
-      } else if (event.target.id === 'filterInterns') {
-        filterInterns = event.target.checked;
-      } else if (event.target.id === 'filterNoTitle') {
-        filterNoTitle = event.target.checked;
-      }
-      
-      // Reapply filter and update visualization if data exists
-      if (hierarchyData && orgData.length > 0) {
-        this.applyFilters();
-        this.rebuildVisualization();
-      }
-    },
-    
-    // Apply filters to organization data
-    applyFilters: function() {
-      filteredOrgData = orgData.filter(user => {
-        // Apply department filter
-        if (filterNoDepartment && (!user.department || user.department === 'Unknown' || user.department.trim() === '')) {
-          return false;
-        }
+  let accessToken = '';
 
-        // Apply title filter
-        if (filterNoTitle && (!user.title || user.title.trim() === '')) {
-          return false;
-        }
+  function getSelectedFields() {
+    const checkboxContainer = document.getElementById('fieldCheckboxes');
+    if (!checkboxContainer) return [];
 
-        // Apply intern filter (check if title contains "intern" - case insensitive)
-        if (filterInterns && user.title && user.title.toLowerCase().includes('intern')) {
-          return false;
-        }
-        
-        return true;
-      });
-    },
-    
-    // Rebuild hierarchy with filtered data
-    rebuildHierarchy: function(node) {
-      if (!node) return null;
-      
-      // Check if this user should be included
-      const userEmail = node.email;
-      const userData = filteredOrgData.find(u => u.email === userEmail);
-      
-      if (!userData) {
-        // User is filtered out, but check if they have children we need to keep
-        if (node.children && node.children.length > 0) {
-          const validChildren = [];
-          for (const child of node.children) {
-            const rebuiltChild = this.rebuildHierarchy(child);
-            if (rebuiltChild) {
-              validChildren.push(rebuiltChild);
-            }
-          }
-          // If this filtered user has valid children, we need to keep them
-          // but we'll promote the children up the hierarchy
-          return validChildren.length > 0 ? validChildren : null;
-        }
-        return null;
-      }
-      
-      // User is not filtered, rebuild their node
-      const newNode = {
-        id: node.id,
-        name: node.name,
-        email: node.email,
-        title: node.title,
-        department: node.department,
-        location: node.location,
-        hasLicense: node.hasLicense,
-        aiEngagement: node.aiEngagement
-      };
-      
-      // Process children
-      if (node.children && node.children.length > 0) {
-        const validChildren = [];
-        for (const child of node.children) {
-          const rebuiltChild = this.rebuildHierarchy(child);
-          if (rebuiltChild) {
-            // Handle case where child might be an array (promoted children)
-            if (Array.isArray(rebuiltChild)) {
-              validChildren.push(...rebuiltChild);
-            } else {
-              validChildren.push(rebuiltChild);
-            }
-          }
-        }
-        if (validChildren.length > 0) {
-          newNode.children = validChildren;
-        }
-      }
-      
-      return newNode;
-    },
-    
-    // Rebuild and refresh visualization
-    rebuildVisualization: function() {
-      const filteredHierarchy = this.rebuildHierarchy(hierarchyData);
-      
-      if (filteredHierarchy) {
-        // Handle case where root might be filtered out
-        let finalHierarchy = filteredHierarchy;
-        if (Array.isArray(filteredHierarchy)) {
-          // If root was filtered, create a virtual root
-          finalHierarchy = {
-            name: 'Organization',
-            email: 'root@org',
-            department: 'Organization',
-            hasLicense: false,
-            children: filteredHierarchy
-          };
-        }
-        
-        // Update statistics with filtered data
-        this.showStatistics();
-        
-        // Update visualization
-        OrgChart.createVisualization(finalHierarchy, filteredOrgData, licensedEmails);
-      }
-    },
-    
-    // Handle CSV file upload
-    handleCsvUpload: function(event) {
-      const file = event.target.files[0];
-      if (!file) return;
-      
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const csvText = e.target.result;
-          const lines = csvText.split('\n');
-          
-          // Clear previous data
-          licensedEmails.clear();
-          licensedUsernames.clear();
-          aiEngagementMap.clear();
-          
-          // Find column indices (case-insensitive)
-          const headers = lines[0].toLowerCase().split(',').map(h => h.trim());
-          const emailIndex = headers.indexOf('email');
-          const engagementIndex = headers.indexOf('avg_daily_messages_total');
-          
-          if (emailIndex === -1) {
-            throw new Error('No "email" column found in CSV');
-          }
-          
-          // Process each row
-          for (let i = 1; i < lines.length; i++) {
-            const row = lines[i].split(',');
-            if (row.length > emailIndex) {
-              const email = row[emailIndex].trim().toLowerCase();
-              if (email) {
-                licensedEmails.add(email);
-                const username = email.split('@')[0];
-                if (username) {
-                  licensedUsernames.add(username);
+    return Array.from(checkboxContainer.querySelectorAll('input[type="checkbox"]:checked'))
+      .map(input => input.value);
+  }
 
-                  // If engagement data exists, store it keyed by username
-                  if (engagementIndex !== -1 && row.length > engagementIndex) {
-                    const avgMessages = parseFloat(row[engagementIndex].trim());
-                    if (!isNaN(avgMessages)) {
-                      // Divide by 3 to get engagement score
-                      const engagementScore = avgMessages / 3;
-                      aiEngagementMap.set(username, engagementScore);
-                    }
-                  }
-                }
-              }
-            }
-          }
-          
-          // Update UI
-          document.getElementById('csvUpload').classList.add('has-file');
-          const statusMessage = engagementIndex !== -1 ? 
-            `✔ Loaded ${licensedEmails.size} licensed email addresses with AI engagement data` :
-            `✔ Loaded ${licensedEmails.size} licensed email addresses`;
-          document.getElementById('csvStatus').innerHTML = `
-            <div class="status-success">
-              ${statusMessage}
-            </div>
-          `;
-          document.getElementById('step3Number').classList.add('step-complete');
-          
-        } catch (error) {
-          document.getElementById('csvStatus').innerHTML = `
-            <div class="status-error">
-              ✗ Error parsing CSV: ${error.message}
-            </div>
-          `;
-        }
-      };
-      
-      reader.readAsText(file);
-    },
-    
-    // Fetch organization data
-    fetchOrgData: async function() {
-      // Get input values
-      accessToken = document.getElementById('graphToken').value.trim();
-      startingEmail = document.getElementById('startingEmail').value.trim();
-      maxUsers = parseInt(document.getElementById('maxUsers').value) || 100;
-      const maxDepth = parseInt(document.getElementById('maxDepth').value) || 4;
-      
-      // Validate inputs
-      if (!accessToken) {
-        this.showError('fetchStatus', 'Please enter a Microsoft Graph access token');
-        return;
-      }
-      
-      if (!startingEmail) {
-        this.showError('fetchStatus', 'Please enter a starting user email address');
-        return;
-      }
+  function updateStatus(elementId, message, type = 'info') {
+    const element = document.getElementById(elementId);
+    if (!element) return;
 
-      // Force email to use company domain
-      const username = startingEmail.split('@')[0].toLowerCase();
-      startingEmail = `${username}@${orgDomain}`;
-      const emailInput = document.getElementById('startingEmail');
-      if (emailInput) {
-        emailInput.value = startingEmail;
-      }
-
-      // Reset data
-      orgData = [];
-      hierarchyData = null;
-      
-      // Show progress
-      document.getElementById('fetchButton').disabled = true;
-      document.getElementById('fetchProgress').style.display = 'block';
-      this.updateProgress(0, 'Fetching starting user...');
-      
-      try {
-        // Mark step 1 as complete
-        document.getElementById('step1Number').classList.add('step-complete');
-        document.getElementById('step2Number').classList.add('step-complete');
-        
-        // Fetch starting user
-        const startingUser = await this.fetchUser(startingEmail);
-        if (!startingUser) {
-          throw new Error('Starting user not found');
-        }
-        
-        // Save successful email to history
-        this.saveEmailToHistory(startingEmail);
-        
-        // Build organization hierarchy with depth limit
-        hierarchyData = await this.buildHierarchy(startingUser, new Set(), 0, maxDepth);
-        
-        // Apply filters
-        this.applyFilters();
-        
-        // Rebuild hierarchy with filtered data
-        const filteredHierarchy = this.rebuildHierarchy(hierarchyData);
-        
-        let finalHierarchy = filteredHierarchy;
-        if (!filteredHierarchy) {
-          throw new Error('No data after filtering');
-        }
-        
-        // Handle case where root might be filtered out
-        if (Array.isArray(filteredHierarchy)) {
-          finalHierarchy = {
-            name: 'Organization',
-            email: 'root@org',
-            department: 'Organization',
-            hasLicense: false,
-            children: filteredHierarchy
-          };
-        }
-        
-        // Mark step 4 as complete
-        document.getElementById('step4Number').classList.add('step-complete');
-        
-        // Show success message
-        const depthLabel = maxDepth === 2 ? '1-2 levels' :
-                          maxDepth === 3 ? '2-3 levels' :
-                          maxDepth === 4 ? '3-5 levels' :
-                          'unlimited depth';
-        let filterInfo = '';
-        if ((filterNoDepartment || filterInterns || filterNoTitle) && filteredOrgData.length < orgData.length) {
-          filterInfo = ` - ${filteredOrgData.length} shown after filtering`;
-        }
-        document.getElementById('fetchStatus').innerHTML = `
-          <div class="status-success">
-            ✔ Successfully fetched ${orgData.length} users (${depthLabel})${filterInfo}
-          </div>
-        `;
-        
-        // Auto-collapse the load section
-        const loadSection = document.getElementById('loadSection');
-        const loadSectionIcon = document.getElementById('loadSectionIcon');
-        if (loadSection && loadSectionIcon) {
-          loadSection.style.display = 'none';
-          loadSectionIcon.textContent = '▶';
-        }
-        
-        // Show statistics
-        this.showStatistics();
-        
-        // Show chart controls section
-        document.getElementById('chartControlsSection').style.display = 'block';
-        
-        // Create visualization
-        OrgChart.createVisualization(finalHierarchy, filteredOrgData, licensedEmails);
-        
-      } catch (error) {
-        console.error('Error fetching org data:', error);
-        this.showError('fetchStatus', `Error: ${error.message}`);
-      } finally {
-        document.getElementById('fetchButton').disabled = false;
-        document.getElementById('fetchProgress').style.display = 'none';
-      }
-    },
-    
-    // Fetch a single user by email
-    fetchUser: async function(email) {
-      try {
-        const response = await fetch(
-          `${graphBaseUrl}/users/${encodeURIComponent(email)}?$select=id,displayName,mail,jobTitle,department,city,country,officeLocation`,
-          {
-            headers: {
-              'Authorization': `Bearer ${accessToken}`,
-              'Content-Type': 'application/json'
-            }
-          }
-        );
-
-        if (!response.ok) {
-          if (response.status === 401) {
-            throw new Error('Invalid or expired access token');
-          }
-          if (response.status === 404) {
-            return null;
-          }
-          throw new Error(`Failed to fetch user: ${response.status}`);
-        }
-
-        const userData = await response.json();
-        return this.processUserData(userData);
-
-      } catch (error) {
-        console.error(`Error fetching user ${email}:`, error);
-        throw error;
-      }
-    },
-    
-    // Process user data
-    processUserData: function(userData) {
-      const email = (userData.mail || userData.userPrincipalName || '').toLowerCase();
-      const username = email.split('@')[0];
-      const user = {
-        id: userData.id,
-        name: userData.displayName || 'Unknown',
-        email: email,
-        title: userData.jobTitle || '',
-        department: userData.department || 'Unknown',
-        location: userData.city || userData.officeLocation || '',
-        hasLicense: false,
-        aiEngagement: 0
-      };
-
-      // Check if user has license using username
-      if (username && licensedUsernames.has(username)) {
-        user.hasLicense = true;
-      }
-
-      // Check if user has AI engagement data using username
-      if (username && aiEngagementMap.has(username)) {
-        user.aiEngagement = aiEngagementMap.get(username);
-      }
-      
-      // Add to org data
-      orgData.push(user);
-      
-      return user;
-    },
-    
-    // Calculate star rating from engagement score
-    getStarRating: function(engagementScore) {
-      if (engagementScore === 0) {
-        return { stars: '—', count: 0, label: 'No AI usage' };
-      } else if (engagementScore <= 1) {
-        return { stars: '★', count: 1, label: 'Light user' };
-      } else if (engagementScore <= 2) {
-        return { stars: '★★', count: 2, label: 'Regular user' };
-      } else if (engagementScore <= 3) {
-        return { stars: '★★★', count: 3, label: 'Active user' };
-      } else if (engagementScore <= 4) {
-        return { stars: '★★★★', count: 4, label: 'Heavy user' };
-      } else if (engagementScore <= 5) {
-        return { stars: '★★★★★', count: 5, label: 'Power user' };
-      } else {
-        return { stars: '★★★★★🚀', count: 5, label: 'Super power user' };
-      }
-    },
-    
-    // Build organization hierarchy
-    buildHierarchy: async function(user, visitedIds, depth = 0, maxDepth = 999) {
-      // Check if we've reached max users or max depth
-      if (orgData.length >= maxUsers || depth >= maxDepth) {
-        return null;
-      }
-      
-      // Check if we've already visited this user
-      if (visitedIds.has(user.id)) {
-        return null;
-      }
-      
-      visitedIds.add(user.id);
-      
-      // Create node for this user
-      const node = {
-        id: user.id,
-        name: user.name,
-        email: user.email,
-        title: user.title,
-        department: user.department,
-        location: user.location,
-        hasLicense: user.hasLicense,
-        aiEngagement: user.aiEngagement,
-        children: []
-      };
-      
-      // Update progress
-      const depthText = maxDepth === 999 ? '' : ` (Level ${depth + 1}/${maxDepth})`;
-      this.updateProgress(
-        (orgData.length / maxUsers) * 100,
-        `Fetching organization structure... (${orgData.length}/${maxUsers} users${depthText})`
-      );
-      
-      // Fetch direct reports only if we haven't reached max depth
-      if (depth < maxDepth - 1) {
-        try {
-          const response = await fetch(
-            `${graphBaseUrl}/users/${user.id}/directReports?$select=id,displayName,mail,jobTitle,department,city,country,officeLocation`,
-            {
-              headers: {
-                'Authorization': `Bearer ${accessToken}`,
-                'Content-Type': 'application/json'
-              }
-            }
-          );
-
-          if (response.status === 401) {
-            throw new Error('Invalid or expired access token');
-          }
-
-          if (response.ok) {
-            const data = await response.json();
-            const reports = data.value || [];
-
-            // Process each direct report
-            for (const reportData of reports) {
-              if (orgData.length >= maxUsers) break;
-
-              const report = this.processUserData(reportData);
-              if (report) {
-                const childNode = await this.buildHierarchy(report, visitedIds, depth + 1, maxDepth);
-                if (childNode) {
-                  node.children.push(childNode);
-                }
-              }
-            }
-          } else {
-            console.error(`Failed to fetch direct reports for ${user.name}: ${response.status}`);
-          }
-        } catch (error) {
-          console.error(`Error fetching direct reports for ${user.name}:`, error);
-          throw error;
-        }
-      }
-      
-      // If no children, delete the empty array to help D3 rendering
-      if (node.children.length === 0) {
-        delete node.children;
-      }
-      
-      return node;
-    },
-    
-    // Update progress bar
-    updateProgress: function(percent, text) {
-      document.getElementById('progressFill').style.width = `${percent}%`;
-      document.getElementById('progressText').textContent = text;
-    },
-    
-    // Show error message
-    showError: function(elementId, message) {
-      document.getElementById(elementId).innerHTML = `
-        <div class="status-error">
-          ✗ ${message}
-        </div>
-      `;
-    },
-    
-    // Show statistics
-    showStatistics: function() {
-      // Use filtered data for statistics
-      const dataToUse = filteredOrgData.length > 0 ? filteredOrgData : orgData;
-      
-      const licensed = dataToUse.filter(u => u.hasLicense).length;
-      const unlicensed = dataToUse.length - licensed;
-      
-      // Calculate AI engagement statistics
-      let engagementStats = { none: 0, light: 0, regular: 0, active: 0, heavy: 0, power: 0, super: 0 };
-      let totalEngaged = 0;
-      dataToUse.forEach(user => {
-        if (user.aiEngagement !== undefined) {
-          const rating = this.getStarRating(user.aiEngagement);
-          if (rating.count === 0) engagementStats.none++;
-          else if (rating.count === 1) engagementStats.light++;
-          else if (rating.count === 2) engagementStats.regular++;
-          else if (rating.count === 3) engagementStats.active++;
-          else if (rating.count === 4) engagementStats.heavy++;
-          else if (rating.count === 5 && user.aiEngagement <= 5) engagementStats.power++;
-          else if (user.aiEngagement > 5) engagementStats.super++;
-          
-          if (user.aiEngagement > 0) totalEngaged++;
-        }
-      });
-      
-      // Calculate department statistics
-      const deptStats = {};
-      dataToUse.forEach(user => {
-        const dept = user.department || 'Unknown';
-        if (!deptStats[dept]) {
-          deptStats[dept] = { total: 0, licensed: 0, engaged: 0, totalEngagement: 0 };
-        }
-        deptStats[dept].total++;
-        if (user.hasLicense) {
-          deptStats[dept].licensed++;
-        }
-        if (user.aiEngagement > 0) {
-          deptStats[dept].engaged++;
-          deptStats[dept].totalEngagement += user.aiEngagement;
-        }
-      });
-      
-      // Sort departments by total users
-      const sortedDepts = Object.entries(deptStats)
-        .sort((a, b) => b[1].total - a[1].total)
-        .map(([dept, stats]) => ({
-          name: dept,
-          total: stats.total,
-          licensed: stats.licensed,
-          engaged: stats.engaged,
-          avgEngagement: stats.engaged > 0 ? (stats.totalEngagement / stats.engaged).toFixed(1) : 0,
-          percent: Math.round((stats.licensed / stats.total) * 100)
-        }));
-      
-      // Create department rows
-      const deptRows = sortedDepts.slice(0, 10).map(dept => {
-        const barColor = dept.percent >= 75 ? 'var(--success)' : 
-                        dept.percent >= 50 ? 'var(--warning)' : 
-                        'var(--danger)';
-        // Escape the department name for safe use in HTML attribute
-        const escapedDeptName = dept.name.replace(/'/g, '&#39;').replace(/"/g, '&quot;');
-        
-        // Calculate star display for average engagement
-        const avgStars = dept.avgEngagement > 0 ? this.getStarRating(parseFloat(dept.avgEngagement)).stars : '—';
-        
-        return `
-          <tr class="dept-row" data-department="${escapedDeptName}" onclick="OrgChart.highlightDepartment(this.dataset.department)">
-            <td style="font-weight: 500;">${dept.name}</td>
-            <td style="text-align: center;">${dept.licensed}/${dept.total}</td>
-            <td style="width: 100px;">
-              <div class="mini-progress">
-                <div class="mini-progress-fill" style="width: ${dept.percent}%; background: ${barColor};"></div>
-                <span class="mini-progress-text">${dept.percent}%</span>
-              </div>
-            </td>
-            ${totalEngaged > 0 ? `<td style="text-align: center;">${dept.engaged > 0 ? `${dept.engaged} (${avgStars})` : '—'}</td>` : ''}
-          </tr>
-        `;
-      }).join('');
-      
-      // Add filter status message if filtering
-      let filterMessage = '';
-      if ((filterNoDepartment || filterInterns || filterNoTitle) && orgData.length > dataToUse.length) {
-        const filtered = orgData.length - dataToUse.length;
-        const filterReasons = [];
-        if (filterNoDepartment) filterReasons.push('no department');
-        if (filterInterns) filterReasons.push('interns');
-        if (filterNoTitle) filterReasons.push('no title');
-        
-        filterMessage = `<div class="filter-status">
-          <span style="color: var(--info);">ℹ️ Showing ${dataToUse.length} of ${orgData.length} users (${filtered} filtered: ${filterReasons.join(', ')})</span>
-        </div>`;
-      }
-      
-      const statsHtml = `
-        ${filterMessage}
-        <div class="stats-grid">
-          <div class="stat-card">
-            <div class="stat-title">Overall Adoption</div>
-            <div class="stat-number">${Math.round(licensed/dataToUse.length*100)}%</div>
-            <div class="stat-subtitle">${licensed} of ${dataToUse.length} users</div>
-            <div class="progress-bar" style="margin-top: 0.5rem;">
-              <div class="progress-fill" style="width: ${(licensed/dataToUse.length)*100}%; background: var(--success);"></div>
-            </div>
-          </div>
-          
-          <div class="stat-card">
-            <div class="stat-row">
-              <span>Total Users:</span>
-              <strong>${dataToUse.length}</strong>
-            </div>
-            <div class="stat-row">
-              <span>Licensed:</span>
-              <strong style="color: var(--success);">${licensed}</strong>
-            </div>
-            <div class="stat-row">
-              <span>Unlicensed:</span>
-              <strong style="color: var(--danger);">${unlicensed}</strong>
-            </div>
-            <div class="stat-row">
-              <span>AI Active:</span>
-              <strong style="color: var(--info);">${totalEngaged}</strong>
-            </div>
-          </div>
-        </div>
-        
-        ${totalEngaged > 0 ? `
-        <div class="engagement-stats">
-          <h4 style="color: var(--primary); margin-bottom: 0.75rem;">AI Engagement Levels</h4>
-          <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; font-size: 0.85rem;">
-            ${engagementStats.light > 0 ? `<span style="padding: 0.25rem 0.5rem; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius);">★ Light: ${engagementStats.light}</span>` : ''}
-            ${engagementStats.regular > 0 ? `<span style="padding: 0.25rem 0.5rem; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius);">★★ Regular: ${engagementStats.regular}</span>` : ''}
-            ${engagementStats.active > 0 ? `<span style="padding: 0.25rem 0.5rem; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius);">★★★ Active: ${engagementStats.active}</span>` : ''}
-            ${engagementStats.heavy > 0 ? `<span style="padding: 0.25rem 0.5rem; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius);">★★★★ Heavy: ${engagementStats.heavy}</span>` : ''}
-            ${engagementStats.power > 0 ? `<span style="padding: 0.25rem 0.5rem; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius);">★★★★★ Power: ${engagementStats.power}</span>` : ''}
-            ${engagementStats.super > 0 ? `<span style="padding: 0.25rem 0.5rem; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius);">★★★★★🚀 Super: ${engagementStats.super}</span>` : ''}
-            ${engagementStats.none > 0 ? `<span style="padding: 0.25rem 0.5rem; background: rgba(0,0,0,0.05); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-light);">— No usage: ${engagementStats.none}</span>` : ''}
-          </div>
-        </div>
-        ` : ''}
-        
-        <div class="dept-stats-table">
-          <h4>License Adoption by Department</h4>
-          <div class="dept-hint">Click a department to highlight in chart</div>
-          <table>
-            <thead>
-              <tr>
-                <th>Department</th>
-                <th>Licensed</th>
-                <th>Adoption</th>
-                ${totalEngaged > 0 ? '<th>AI Active</th>' : ''}
-              </tr>
-            </thead>
-            <tbody>
-              ${deptRows}
-            </tbody>
-          </table>
-          ${sortedDepts.length > 10 ? `<div class="table-footer">...and ${sortedDepts.length - 10} more departments</div>` : ''}
-        </div>
-      `;
-      
-      document.getElementById('statsSection').style.display = 'block';
-      document.getElementById('statsContent').innerHTML = statsHtml;
+    if (!message) {
+      element.textContent = '';
+      element.className = 'status-message';
+      element.style.display = 'none';
+      return;
     }
-  }; 
-})();
 
-// Expose GraphAPI to global scope for inline event handlers
-window.GraphAPI = GraphAPI;
+    element.textContent = message;
+    element.className = `status-message status-${type}`;
+    element.style.display = 'flex';
+  }
+
+  function showLoading(message) {
+    const overlay = document.getElementById('loadingOverlay');
+    const text = document.getElementById('loadingText');
+    if (overlay) overlay.classList.add('active');
+    if (text) text.textContent = message || 'Processing...';
+  }
+
+  function hideLoading() {
+    const overlay = document.getElementById('loadingOverlay');
+    if (overlay) overlay.classList.remove('active');
+  }
+
+  function parseCsvFile(file) {
+    return new Promise((resolve, reject) => {
+      Papa.parse(file, {
+        complete: results => {
+          if (results.errors && results.errors.length > 0) {
+            reject(new Error(results.errors[0].message));
+            return;
+          }
+          const data = Array.isArray(results.data) ? results.data : [];
+          resolve(cleanParsedRows(data));
+        },
+        error: error => reject(error)
+      });
+    });
+  }
+
+  function parseExcelFile(file) {
+    return file.arrayBuffer().then(buffer => {
+      const workbook = XLSX.read(buffer, { type: 'array' });
+      const firstSheet = workbook.SheetNames[0];
+      if (!firstSheet) {
+        throw new Error('The workbook does not contain any sheets.');
+      }
+      const worksheet = workbook.Sheets[firstSheet];
+      const rows = XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: '' });
+      return cleanParsedRows(rows);
+    });
+  }
+
+  function cleanParsedRows(rows) {
+    return rows
+      .map(row => Array.isArray(row) ? row.map(cell => (cell === null || cell === undefined ? '' : cell)) : [])
+      .filter(row => row.some(cell => cell !== '' && cell !== null && cell !== undefined));
+  }
+
+  function handleFileUpload(event) {
+    const file = event.target.files ? event.target.files[0] : null;
+    if (!file) return;
+
+    const extension = file.name.split('.').pop().toLowerCase();
+    const supported = ['csv', 'xlsx', 'xls'];
+    if (!supported.includes(extension)) {
+      updateStatus('loadStatus', 'Unsupported file type. Upload a CSV or Excel file.', 'error');
+      event.target.value = '';
+      return;
+    }
+    const uploadArea = document.getElementById('fileUploadArea');
+    if (uploadArea) uploadArea.classList.remove('has-file');
+
+    updateStatus('loadStatus', 'Loading file...', 'info');
+    showLoading('Reading uploaded file...');
+
+    const parser = extension === 'csv' ? parseCsvFile : parseExcelFile;
+
+    parser(file)
+      .then(rows => {
+        if (!rows.length) {
+          throw new Error('The file did not contain any data.');
+        }
+        const [headerRow, ...dataRows] = rows;
+        if (!headerRow || !headerRow.length) {
+          throw new Error('The first row of the file must contain headers.');
+        }
+
+        const columns = headerRow.map((cell, idx) => {
+          const label = cell === null || cell === undefined || cell === '' ? `Column ${idx + 1}` : cell;
+          return label.toString();
+        });
+
+        const filteredRows = dataRows
+          .map(row => columns.map((_, idx) => {
+            const value = row[idx];
+            return value === null || value === undefined ? '' : value;
+          }))
+          .filter(row => row.some(cell => cell !== '' && cell !== null && cell !== undefined));
+
+        if (!filteredRows.length) {
+          throw new Error('No data rows were found after the header.');
+        }
+
+        DataTable.loadData(columns, filteredRows);
+        updateStatus('loadStatus', `${file.name} loaded successfully (${filteredRows.length} rows).`, 'success');
+        if (uploadArea) uploadArea.classList.add('has-file');
+        setSectionCollapsed('loadSection', true);
+        updateStatus('fetchStatus', '');
+        updateDownloadButtons();
+        updateFetchButtonState();
+      })
+      .catch(error => {
+        console.error('Error loading file:', error);
+        updateStatus('loadStatus', error.message || 'Unable to read the uploaded file.', 'error');
+      })
+      .finally(() => hideLoading());
+  }
+
+  function handlePasteLoad() {
+    const textarea = document.getElementById('pasteEmails');
+    if (!textarea) return;
+
+    const raw = textarea.value.trim();
+    if (!raw) {
+      updateStatus('loadStatus', 'Paste one or more email addresses to load the table.', 'error');
+      return;
+    }
+
+    const emails = raw
+      .split(/\s|,|;|\n|\r/)
+      .map(value => value.trim())
+      .filter(value => value.length > 0);
+
+    if (!emails.length) {
+      updateStatus('loadStatus', 'No valid email addresses were detected.', 'error');
+      return;
+    }
+
+    const uniqueEmails = Array.from(new Set(emails));
+    const rows = uniqueEmails.map(email => [email]);
+    DataTable.loadData(['Email'], rows);
+    updateStatus('loadStatus', `Loaded ${rows.length} email${rows.length === 1 ? '' : 's'} from pasted list.`, 'success');
+    const uploadArea = document.getElementById('fileUploadArea');
+    if (uploadArea) uploadArea.classList.remove('has-file');
+    setSectionCollapsed('loadSection', true);
+    updateStatus('fetchStatus', '');
+    updateDownloadButtons();
+    updateFetchButtonState();
+  }
+
+  function updateAppendModeUI() {
+    const insertInput = document.getElementById('insertIndex');
+    const selectedMode = document.querySelector('input[name="appendMode"]:checked');
+    if (!insertInput) return;
+
+    if (selectedMode && selectedMode.value === 'index') {
+      insertInput.disabled = false;
+    } else {
+      insertInput.disabled = true;
+      insertInput.value = '';
+    }
+  }
+
+  function getAppendMode() {
+    const selected = document.querySelector('input[name="appendMode"]:checked');
+    if (!selected || selected.value === 'end') {
+      return { mode: 'end', index: DataTable.getColumnCount() };
+    }
+
+    const insertInput = document.getElementById('insertIndex');
+    if (!insertInput || !insertInput.value) {
+      return { mode: 'invalid' };
+    }
+
+    const parsed = Number.parseInt(insertInput.value, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      return { mode: 'invalid' };
+    }
+
+    return { mode: 'index', index: Math.min(parsed - 1, DataTable.getColumnCount()) };
+  }
+
+  function updateDownloadButtons() {
+    const hasData = DataTable.hasData();
+    const csvButton = document.getElementById('downloadCsvButton');
+    const excelButton = document.getElementById('downloadExcelButton');
+    if (csvButton) csvButton.disabled = !hasData;
+    if (excelButton) excelButton.disabled = !hasData;
+  }
+
+  function updateFetchButtonState() {
+    const fetchButton = document.getElementById('fetchButton');
+    if (!fetchButton) return;
+
+    const hasToken = accessToken.length > 0;
+    const hasTableData = DataTable.hasData();
+    const hasFields = getSelectedFields().length > 0;
+    fetchButton.disabled = !(hasToken && hasTableData && hasFields);
+  }
+
+  function downloadCsv() {
+    const exportData = DataTable.getDataForExport();
+    if (!exportData.columns.length || !exportData.rows.length) return;
+
+    const csv = Papa.unparse({ fields: exportData.columns, data: exportData.rows });
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `profile-data-${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  function downloadExcel() {
+    const exportData = DataTable.getDataForExport();
+    if (!exportData.columns.length || !exportData.rows.length) return;
+
+    const worksheet = XLSX.utils.aoa_to_sheet([
+      exportData.columns,
+      ...exportData.rows
+    ]);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Profile Data');
+    XLSX.writeFile(workbook, `profile-data-${new Date().toISOString().slice(0, 10)}.xlsx`);
+  }
+
+  function formatFieldValue(fieldKey, rawValue) {
+    if (rawValue === undefined || rawValue === null) {
+      return '';
+    }
+    if (Array.isArray(rawValue)) {
+      return rawValue.filter(Boolean).join('; ');
+    }
+    if (typeof rawValue === 'object') {
+      return JSON.stringify(rawValue);
+    }
+    return rawValue.toString();
+  }
+
+  async function fetchUserProfile(email, fields) {
+    const selectFields = fields.join(',');
+    const endpoint = `${graphBaseUrl}/users/${encodeURIComponent(email)}?$select=${selectFields}`;
+    const response = await fetch(endpoint, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      }
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      const message = errorBody.error && errorBody.error.message
+        ? errorBody.error.message
+        : `Request failed with status ${response.status}`;
+      throw new Error(message);
+    }
+
+    return response.json();
+  }
+
+  async function fetchProfileData() {
+    updateStatus('fetchStatus', '');
+
+    if (!accessToken) {
+      updateStatus('fetchStatus', 'Provide a Microsoft Graph access token to fetch profile data.', 'error');
+      return;
+    }
+
+    if (!DataTable.hasData()) {
+      updateStatus('fetchStatus', 'Load a CSV, Excel file, or paste emails before fetching profile data.', 'error');
+      return;
+    }
+
+    const selectedFields = getSelectedFields();
+    if (!selectedFields.length) {
+      updateStatus('fetchStatus', 'Select at least one profile field to append.', 'error');
+      return;
+    }
+
+    const appendMode = getAppendMode();
+    if (appendMode.mode === 'invalid') {
+      updateStatus('fetchStatus', 'Enter a valid column position (1 or greater) to insert new data.', 'error');
+      return;
+    }
+
+    const emailColumnIndex = DataTable.findEmailColumn();
+    if (emailColumnIndex === -1) {
+      updateStatus('fetchStatus', 'Unable to find an email column. Ensure a column named "Email" or "UserPrincipalName" exists.', 'error');
+      return;
+    }
+
+    const rowCount = DataTable.getRowCount();
+    if (!rowCount) {
+      updateStatus('fetchStatus', 'No rows available to process.', 'error');
+      return;
+    }
+
+    showLoading('Retrieving Microsoft 365 profiles...');
+
+    const fieldLabels = selectedFields.map(field => {
+      const definition = fieldDefinitions.find(item => item.key === field);
+      return definition ? definition.label : field;
+    });
+
+    const valuesByField = fieldLabels.reduce((acc, label) => {
+      acc[label] = new Array(rowCount).fill('');
+      return acc;
+    }, {});
+
+    const errors = [];
+
+    try {
+      for (let index = 0; index < rowCount; index++) {
+        const email = DataTable.getCellValue(index, emailColumnIndex).trim();
+        if (!email) {
+          errors.push(`Row ${index + 1}: missing email address.`);
+          continue;
+        }
+
+        updateStatus('fetchStatus', `Fetching profile ${index + 1} of ${rowCount} (${email})...`, 'info');
+
+        try {
+          const profile = await fetchUserProfile(email, selectedFields);
+          if (!profile) {
+            errors.push(`${email}: user not found.`);
+            continue;
+          }
+
+          selectedFields.forEach(fieldKey => {
+            const definition = fieldDefinitions.find(item => item.key === fieldKey);
+            const label = definition ? definition.label : fieldKey;
+            valuesByField[label][index] = formatFieldValue(fieldKey, profile[fieldKey]);
+          });
+        } catch (error) {
+          errors.push(`${email}: ${error.message}`);
+        }
+      }
+
+      DataTable.applyFieldValues(fieldLabels, valuesByField, appendMode);
+
+      if (errors.length) {
+        updateStatus('fetchStatus', `Completed with ${errors.length} issue${errors.length === 1 ? '' : 's'}. Check console for details.`, 'warning');
+        console.warn('Profile fetch issues:', errors);
+      } else {
+        updateStatus('fetchStatus', 'Profile data appended successfully.', 'success');
+      }
+
+      updateDownloadButtons();
+    } catch (error) {
+      console.error('Error fetching profile data:', error);
+      updateStatus('fetchStatus', error.message || 'Failed to fetch profile data.', 'error');
+    } finally {
+      hideLoading();
+      updateFetchButtonState();
+    }
+  }
+
+  function attachEventListeners() {
+    const tokenInput = document.getElementById('graphToken');
+    if (tokenInput) {
+      tokenInput.addEventListener('input', event => {
+        accessToken = event.target.value.trim();
+        updateFetchButtonState();
+      });
+    }
+
+    const fileInput = document.getElementById('dataFile');
+    if (fileInput) {
+      fileInput.addEventListener('change', handleFileUpload);
+    }
+
+    const pasteButton = document.getElementById('pasteLoadButton');
+    if (pasteButton) {
+      pasteButton.addEventListener('click', handlePasteLoad);
+    }
+
+    const appendModeRadios = document.querySelectorAll('input[name="appendMode"]');
+    appendModeRadios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        updateAppendModeUI();
+        updateFetchButtonState();
+      });
+    });
+
+    const checkboxContainer = document.getElementById('fieldCheckboxes');
+    if (checkboxContainer) {
+      checkboxContainer.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+        checkbox.addEventListener('change', updateFetchButtonState);
+      });
+    }
+
+    const fetchButton = document.getElementById('fetchButton');
+    if (fetchButton) {
+      fetchButton.addEventListener('click', fetchProfileData);
+    }
+
+    const csvButton = document.getElementById('downloadCsvButton');
+    if (csvButton) {
+      csvButton.addEventListener('click', downloadCsv);
+    }
+
+    const excelButton = document.getElementById('downloadExcelButton');
+    if (excelButton) {
+      excelButton.addEventListener('click', downloadExcel);
+    }
+  }
+
+  return {
+    initialize: function() {
+      attachEventListeners();
+      updateAppendModeUI();
+      updateDownloadButtons();
+      updateFetchButtonState();
+    },
+
+    updateDownloadButtons,
+    updateFetchButtonState
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -3,332 +3,178 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Organization Chart Visualizer with ChatGPT License Tracking</title>
+  <title>Microsoft Profile Data Appender</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div class="app-container">
     <header class="header">
-      <h1>Organization Chart Visualizer</h1>
-      <button class="btn btn-secondary" onclick="toggleDarkMode()">🌙 Dark Mode</button>
+      <h1>Microsoft Profile Data Appender</h1>
+      <div class="header-actions">
+        <button class="btn btn-secondary" onclick="toggleDarkMode()">🌙 Dark Mode</button>
+      </div>
     </header>
-    
+
     <div class="main-content">
-      <!-- Setup Panel -->
-      <div class="setup-panel" id="setupPanel">
-        
-        <!-- Collapsible Load Section -->
+      <aside class="setup-panel" id="setupPanel">
         <div class="collapsible-section">
-          <div class="collapsible-header" onclick="toggleSection('loadSection')">
-            <span class="collapse-icon" id="loadSectionIcon">▼</span>
-            <h3 style="margin: 0;">Load Organization Data</h3>
+          <div class="collapsible-header" onclick="toggleSection('tokenSection')">
+            <span class="collapse-icon" id="tokenSectionIcon">▼</span>
+            <h3 style="margin: 0;">Microsoft Graph Token</h3>
           </div>
-          
-          <div class="collapsible-content" id="loadSection">
-            <!-- Step 1: Graph Token -->
+
+          <div class="collapsible-content" id="tokenSection">
             <div class="wizard-step">
-              <h3>
-                <span class="step-number" id="step1Number">1</span>
-                Microsoft Graph Token
-              </h3>
-              
+              <h3>Get an Access Token</h3>
               <div class="help-info">
                 <h4>How to get your Graph Token:</h4>
                 <ol>
                   <li>Go to <a href="https://developer.microsoft.com/en-us/graph/graph-explorer" target="_blank">Microsoft Graph Explorer</a></li>
-                  <li>Sign in with your Microsoft work account</li>
-                  <li>Click "Access Token" tab on the left</li>
-                  <li>Copy the entire token and paste it below</li>
+                  <li>Sign in with your Microsoft 365 work account</li>
+                  <li>Run any sample query, then open the <strong>Access Token</strong> tab on the left</li>
+                  <li>Copy the entire token string and paste it below</li>
                 </ol>
               </div>
-              
+
               <div class="form-group">
                 <label for="graphToken">Access Token:</label>
                 <textarea id="graphToken" placeholder="Paste your Microsoft Graph access token here..."></textarea>
               </div>
             </div>
-            
-            <!-- Step 2: Starting Point -->
+          </div>
+        </div>
+
+        <div class="collapsible-section" id="loadSectionContainer">
+          <div class="collapsible-header" onclick="toggleSection('loadSection')">
+            <span class="collapse-icon" id="loadSectionIcon">▼</span>
+            <h3 style="margin: 0;">Load Email Data</h3>
+          </div>
+
+          <div class="collapsible-content" id="loadSection">
             <div class="wizard-step">
-              <h3>
-                <span class="step-number" id="step2Number">2</span>
-                Starting User
-              </h3>
-              
-              <div class="form-group">
-                <label for="startingEmail">Starting User Email:</label>
-                <div style="position: relative;">
-                  <input type="email" id="startingEmail" placeholder="user@company.com" list="emailHistory">
-                  <datalist id="emailHistory"></datalist>
-                  <button type="button" class="btn-clear-history" onclick="GraphAPI.clearEmailHistory()" title="Clear email history">
-                    ✕
-                  </button>
-                </div>
-                <small style="color: var(--text-light); display: block; margin-top: 0.25rem;">
-                  Start typing or select from previous searches
-                </small>
-              </div>
-              
-              <div class="form-group">
-                <label for="maxDepth">Hierarchy Depth:</label>
-                <select id="maxDepth">
-                  <option value="2">1-2 Levels (Direct reports)</option>
-                  <option value="3">2-3 Levels (Direct reports + their teams)</option>
-                  <option value="4" selected>3-5 Levels (Team structure)</option>
-                  <option value="999">Unlimited (Full hierarchy)</option>
-                </select>
-                <small style="color: var(--text-light); display: block; margin-top: 0.25rem;">
-                  Controls how many levels deep to fetch in the organization
-                </small>
-              </div>
-              
-              <div class="form-group">
-                <label for="maxUsers">Maximum Users to Fetch:</label>
-                <input type="number" id="maxUsers" value="100" min="10" max="500">
-                <small style="color: var(--text-light); display: block; margin-top: 0.25rem;">
-                  Safety limit to prevent excessive API calls
-                </small>
-              </div>
-            </div>
-            
-            <!-- Step 3: License CSV -->
-            <div class="wizard-step">
-              <h3>
-                <span class="step-number" id="step3Number">3</span>
-                ChatGPT License List (Optional)
-              </h3>
-              
-              <div class="file-upload" id="csvUpload">
-                <input type="file" id="csvFile" accept=".csv">
-                <label class="file-upload-label" for="csvFile">
-                  📁 Click to upload CSV with licensed emails<br>
-                  <small>Format: Single column with 'email' header</small>
+              <h3>Upload CSV or Excel</h3>
+              <p class="helper-text">Upload a list of users or paste email addresses to build the table.</p>
+
+              <div class="file-upload" id="fileUploadArea">
+                <input type="file" id="dataFile" accept=".csv,.xlsx,.xls">
+                <label class="file-upload-label" for="dataFile">
+                  📁 Click to upload or drag in a CSV/XLSX file<br>
+                  <small>First row should contain column headers.</small>
                 </label>
               </div>
-              
-              <div id="csvStatus"></div>
-            </div>
-            
-            <!-- Step 4: Fetch Data -->
-            <div class="wizard-step">
-              <h3>
-                <span class="step-number" id="step4Number">4</span>
-                Fetch Organization Data
-              </h3>
-              
-              <button class="btn btn-primary" onclick="GraphAPI.fetchOrgData()" id="fetchButton">
-                🔄 Fetch Organization Data
-              </button>
-              
-              <div id="fetchProgress" class="progress-container" style="display: none;">
-                <div class="progress-bar">
-                  <div class="progress-fill" id="progressFill"></div>
-                </div>
-                <div class="progress-text" id="progressText">Initializing...</div>
+
+              <div class="divider"><span>or</span></div>
+
+              <div class="form-group">
+                <label for="pasteEmails">Paste Email List:</label>
+                <textarea id="pasteEmails" placeholder="user1@contoso.com&#10;user2@contoso.com"></textarea>
               </div>
-              
-              <div id="fetchStatus"></div>
+
+              <button class="btn btn-secondary" id="pasteLoadButton">Load Pasted Emails</button>
+              <div id="loadStatus" class="status-message" style="display: none;"></div>
             </div>
           </div>
         </div>
-        
-        <!-- Statistics Section (Always Visible) -->
-        <div class="wizard-step" id="statsSection" style="display: none;">
-          <h3>📊 Statistics</h3>
-          <div id="statsContent"></div>
-        </div>
-        
-        <!-- Chart Controls Section -->
-        <div class="collapsible-section" id="chartControlsSection" style="display: none;">
-          <div class="collapsible-header" onclick="toggleSection('controlsContent')">
-            <span class="collapse-icon" id="controlsContentIcon">▼</span>
-            <h3 style="margin: 0;">Chart Controls</h3>
+
+        <div class="wizard-step" id="fieldOptions">
+          <h3>Profile Fields to Append</h3>
+          <p class="helper-text">Select the Microsoft 365 profile details to retrieve for each user.</p>
+
+          <div class="checkbox-grid" id="fieldCheckboxes">
+            <label><input type="checkbox" value="displayName" checked>Display Name</label>
+            <label><input type="checkbox" value="jobTitle" checked>Job Title</label>
+            <label><input type="checkbox" value="department" checked>Department</label>
+            <label><input type="checkbox" value="officeLocation">Office Location</label>
+            <label><input type="checkbox" value="companyName">Company Name</label>
+            <label><input type="checkbox" value="mail">Mail</label>
+            <label><input type="checkbox" value="userPrincipalName">User Principal Name</label>
+            <label><input type="checkbox" value="businessPhones">Business Phones</label>
+            <label><input type="checkbox" value="mobilePhone">Mobile Phone</label>
+            <label><input type="checkbox" value="preferredLanguage">Preferred Language</label>
+            <label><input type="checkbox" value="givenName">Given Name</label>
+            <label><input type="checkbox" value="surname">Surname</label>
           </div>
-          
-          <div class="collapsible-content" id="controlsContent">
-            <div class="controls-panel">
-              <div class="control-group-vertical">
-                <label>Color By:</label>
-                <select id="colorBy" onchange="OrgChart.updateVisualization()">
-                  <option value="department">Department</option>
-                  <option value="license" selected>ChatGPT License</option>
-                  <option value="level">Hierarchy Level</option>
-                </select>
-              </div>
-              
-              <div class="control-group-vertical">
-                <label for="filterNoDept" style="display: flex; align-items: center; gap: 0.5rem;">
-                  <input type="checkbox" id="filterNoDept" checked style="width: auto;">
-                  Hide No Department
-                </label>
-              </div>
-              
-              <div class="control-group-vertical">
-                <label for="filterInterns" style="display: flex; align-items: center; gap: 0.5rem;">
-                  <input type="checkbox" id="filterInterns" checked style="width: auto;">
-                  Hide Interns
-                </label>
-              </div>
 
-              <div class="control-group-vertical">
-                <label for="filterNoTitle" style="display: flex; align-items: center; gap: 0.5rem;">
-                  <input type="checkbox" id="filterNoTitle" checked style="width: auto;">
-                  Hide No Title
-                </label>
-              </div>
+          <div class="form-group">
+            <label>Append Location:</label>
+            <div class="inline-options">
+              <label class="inline-option"><input type="radio" name="appendMode" value="end" checked> Append to end</label>
+              <label class="inline-option"><input type="radio" name="appendMode" value="index"> Insert at column</label>
+              <input type="number" id="insertIndex" class="small-input" min="1" placeholder="Column position" disabled>
+            </div>
+            <small class="form-hint">Use a 1-based column number (e.g., 3 inserts before the current third column).</small>
+          </div>
 
-              <div class="control-group-vertical">
-                <label for="showStars" style="display: flex; align-items: center; gap: 0.5rem;">
-                  <input type="checkbox" id="showStars" checked style="width: auto;">
-                  Show Engagement Stars
-                </label>
-              </div>
+          <button class="btn btn-primary" id="fetchButton" disabled>Fetch Profile Data</button>
+          <div id="fetchStatus" class="status-message" style="display: none;"></div>
+        </div>
 
-              <div class="control-group-vertical">
-                <label for="dimMode">Non-highlighted Display:</label>
-                <select id="dimMode">
-                  <option value="dim" selected>Dim</option>
-                  <option value="transparent">Transparent</option>
-                  <option value="hidden">Hidden</option>
-                </select>
-                <small style="color: var(--text-light); display: block; margin-top: 0.25rem;">
-                  Choose how nodes and links that are not part of the current highlight are shown.
-                </small>
-              </div>
+        <div class="wizard-step">
+          <h3>Download Updated Table</h3>
+          <p class="helper-text">Export the current table, including any appended profile data.</p>
+          <div class="button-row">
+            <button class="btn btn-secondary" id="downloadCsvButton" disabled>⬇️ Download CSV</button>
+            <button class="btn btn-secondary" id="downloadExcelButton" disabled>⬇️ Download Excel</button>
+          </div>
+        </div>
+      </aside>
 
-              <div class="control-group-vertical">
-                <label>Horizontal Spacing: <span id="horizontalValue">200</span></label>
-                <input type="range" id="horizontalSpacing" min="100" max="400" value="200"
-                       oninput="OrgChart.updateSpacing('horizontal', this.value)">
-              </div>
-              
-              <div class="control-group-vertical">
-                <label>Vertical Spacing: <span id="verticalValue">1.0</span></label>
-                <input type="range" id="verticalSpacing" min="0.5" max="5" step="0.1" value="1" 
-                        oninput="OrgChart.updateSpacing('vertical', this.value)">
-              </div>
-              
-
+      <main class="viz-container">
+        <div class="table-container">
+          <div class="table-toolbar">
+            <div id="tableSummary">Upload a CSV or Excel file to begin.</div>
+          </div>
+          <div class="table-wrapper" id="tableWrapper">
+            <table id="dataTable">
+              <thead></thead>
+              <tbody></tbody>
+            </table>
+            <div class="table-empty-state" id="tableEmptyState">
+              <p>No data loaded yet.</p>
+              <p class="helper-text">Upload a CSV/Excel file or paste an email list to populate the table.</p>
             </div>
           </div>
         </div>
-      </div>
-      
-      <!-- Visualization Container -->
-      <div class="viz-container">
-        <div id="treeContainer"></div>
-        
-        <!-- Bottom Controls -->
-        <div class="bottom-controls" id="bottomControls" style="display: none;">
-          <input type="text" id="searchInput" placeholder="Search name or title"
-                 onkeydown="if(event.key==='Enter') OrgChart.searchByNameTitle()" style="max-width: 180px;">
-          <button class="icon-btn" onclick="OrgChart.searchByNameTitle()" title="Search">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="11" cy="11" r="8"></circle>
-              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-            </svg>
-          </button>
-            <button class="icon-btn" onclick="OrgChart.clearHighlight()" title="Clear Search" id="clearSearchBtn" style="display: none;">
-              ✕
-            </button>
-            <button class="icon-btn" onclick="OrgChart.expandOneLevel()" title="Expand One Level">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <line x1="12" y1="8" x2="12" y2="16"></line>
-                <line x1="8" y1="12" x2="16" y2="12"></line>
-              </svg>
-            </button>
-            <button class="icon-btn" onclick="OrgChart.collapseOneLevel()" title="Collapse One Level">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <line x1="8" y1="12" x2="16" y2="12"></line>
-              </svg>
-            </button>
-            <button class="icon-btn" onclick="OrgChart.expandAll()" title="Expand All">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="10"></circle>
-                <line x1="12" y1="8" x2="12" y2="16"></line>
-                <line x1="8" y1="12" x2="16" y2="12"></line>
-              </svg>
-            </button>
-            <button class="icon-btn" onclick="OrgChart.collapseAll()" title="Collapse All">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="12" cy="12" r="10"></circle>
-              <line x1="8" y1="12" x2="16" y2="12"></line>
-            </svg>
-          </button>
-          <button class="icon-btn" onclick="OrgChart.resetView()" title="Reset View">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M21 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6"></path>
-              <polyline points="15 3 21 3 21 9"></polyline>
-              <line x1="10" y1="14" x2="21" y2="3"></line>
-            </svg>
-          </button>
-          <button class="icon-btn" onclick="OrgChart.downloadCSV()" title="Download CSV">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-              <polyline points="7 10 12 15 17 10"></polyline>
-              <line x1="12" y1="15" x2="12" y2="3"></line>
-            </svg>
-          </button>
-          <button class="icon-btn" onclick="OrgChart.toggleLicenseHighlight()" title="Toggle Licensed Users" id="licenseToggleBtn">
-            🔑
-          </button>
-          <button class="icon-btn" onclick="OrgChart.clearHighlight()" title="Clear Highlight" id="clearHighlightBtn" style="display: none;">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="12" cy="12" r="10"></circle>
-              <line x1="15" y1="9" x2="9" y2="15"></line>
-              <line x1="9" y1="9" x2="15" y2="15"></line>
-            </svg>
-          </button>
-        </div>
-        
-        <div class="legend" id="legend" style="display: none;">
-          <div id="selectedUserSection" style="display: none;"></div>
-          <div id="legendContent"></div>
-        </div>
-        <div class="stats-panel" id="statsPanel" style="display: none;"></div>
-      </div>
+      </main>
     </div>
   </div>
-  
-  <!-- Tooltip -->
-  <div class="tooltip" id="tooltip"></div>
-  
-  <!-- Loading Overlay -->
+
   <div class="loading-overlay" id="loadingOverlay">
     <div class="spinner"></div>
     <div class="loading-text" id="loadingText">Processing...</div>
   </div>
-  
-  <!-- D3.js -->
-  <script src="https://d3js.org/d3.v7.min.js"></script>
-  
-  <!-- Application Scripts -->
-  <script src="graph-api.js"></script>
+
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <script src="visualization.js"></script>
-  
+  <script src="graph-api.js"></script>
   <script>
-    // Initialize application
     document.addEventListener('DOMContentLoaded', () => {
+      DataTable.initialize();
       GraphAPI.initialize();
-      OrgChart.initialize();
     });
-    
-    // Dark mode toggle
+
     function toggleDarkMode() {
       document.body.classList.toggle('dark-mode');
     }
-    
-    // Toggle collapsible sections
+
     function toggleSection(sectionId) {
       const section = document.getElementById(sectionId);
+      const isCollapsed = section && section.style.display === 'none';
+      setSectionCollapsed(sectionId, !isCollapsed);
+    }
+
+    function setSectionCollapsed(sectionId, collapsed) {
+      const section = document.getElementById(sectionId);
       const icon = document.getElementById(sectionId + 'Icon');
-      
-      if (section.style.display === 'none') {
-        section.style.display = 'block';
-        icon.textContent = '▼';
-      } else {
+      if (!section || !icon) return;
+
+      if (collapsed) {
         section.style.display = 'none';
         icon.textContent = '▶';
+      } else {
+        section.style.display = 'block';
+        icon.textContent = '▼';
       }
     }
   </script>

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,12 @@ body {
   align-items: center;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .header h1 {
   font-size: 1.5rem;
   font-weight: 600;
@@ -363,12 +369,77 @@ textarea {
   background: rgba(0, 168, 84, 0.05);
 }
 
+.helper-text {
+  color: var(--text-light);
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 1.25rem 0;
+  color: var(--text-light);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+  margin: 0 0.75rem;
+}
+
+.checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.5rem 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.inline-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.inline-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.small-input {
+  width: 140px;
+  padding: 0.5rem 0.75rem;
+}
+
+.form-hint {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--text-light);
+  font-size: 0.85rem;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 /* Status Messages */
 .status-message {
   padding: 0.75rem;
   border-radius: var(--radius);
   margin-top: 1rem;
-  display: flex;
+  display: none;
   align-items: center;
   gap: 0.5rem;
 }
@@ -377,24 +448,24 @@ textarea {
   background: rgba(0, 168, 84, 0.1);
   color: var(--success);
   border: 1px solid var(--success);
-  padding: 0.75rem;
-  border-radius: var(--radius);
-  margin-top: 1rem;
 }
 
 .status-error {
   background: rgba(231, 76, 60, 0.1);
   color: var(--danger);
   border: 1px solid var(--danger);
-  padding: 0.75rem;
-  border-radius: var(--radius);
-  margin-top: 1rem;
 }
 
 .status-info {
   background: rgba(52, 152, 219, 0.1);
   color: var(--info);
   border: 1px solid var(--info);
+}
+
+.status-warning {
+  background: rgba(243, 156, 18, 0.1);
+  color: var(--warning);
+  border: 1px solid var(--warning);
 }
 
 /* Progress Indicator */
@@ -594,17 +665,86 @@ input[type="checkbox"] {
   cursor: pointer;
 }
 
-/* Visualization Container */
+/* Main Table Container */
 .viz-container {
   flex: 1;
   background: var(--bg);
-  position: relative;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
-#treeContainer {
+.table-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  gap: 1rem;
+}
+
+.table-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-light);
+}
+
+.table-wrapper {
+  flex: 1;
+  position: relative;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: auto;
+}
+
+.table-wrapper table {
   width: 100%;
-  height: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.table-wrapper thead {
+  background: var(--bg-secondary);
+  z-index: 1;
+}
+
+.table-wrapper th,
+.table-wrapper td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+  color: var(--text);
+  min-width: 120px;
+}
+
+.table-wrapper thead th {
+  position: sticky;
+  top: 0;
+  background: var(--bg-secondary);
+}
+
+.table-wrapper.empty table {
+  display: none;
+}
+
+.table-wrapper.empty .table-empty-state {
+  display: flex;
+}
+
+.table-empty-state {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: center;
+  color: var(--text-light);
+  padding: 2rem;
 }
 
 /* Bottom Controls */

--- a/visualization.js
+++ b/visualization.js
@@ -1,1043 +1,220 @@
-// D3.js Organization Chart Visualization
-const OrgChart = (function() {
+// Data table and presentation utilities
+const DataTable = (function() {
   'use strict';
-  
-  // Private variables
-  let svg = null;
-  let g = null;
-  let root = null;
-  let treemap = null;
-  let zoom = null;
-  let i = 0;
-  let orgData = [];
-  let licensedEmails = new Set();
-  let highlightedDepartment = null;
-  let highlightedNodes = null;
-  let licenseHighlightActive = false;
-  let currentExpandLevel = 1;
 
-  // Configuration
-  const config = {
-    horizontalSpacing: 200,
-    verticalSpacing: 1,
-    nodeRadius: 10,
-    duration: 750,
-    margin: { top: 20, right: 120, bottom: 20, left: 120 },
-    showEngagementStars: true,
-    dimMode: 'dim'
-  };
-  
-  // Color scales
-  let departmentColorScale = null;
-  let levelColorScale = null;
+  let columns = [];
+  let rows = [];
+  let tableElement = null;
+  let tableHead = null;
+  let tableBody = null;
+  let tableWrapper = null;
+  let summaryElement = null;
+  let emptyStateElement = null;
 
-  // Helper functions
-  function getAllChildren(node) {
-    return [
-      ...(node.children || []),
-      ...(node._children || [])
-    ];
+  function normalizeRow(row) {
+    if (!Array.isArray(row)) {
+      return Array.from({ length: columns.length }, () => '');
+    }
+    return columns.map((_, idx) => formatCell(row[idx]));
   }
 
-  function countDescendants(node) {
-    return getAllChildren(node)
-      .reduce((sum, child) => sum + 1 + countDescendants(child), 0);
+  function formatCell(value) {
+    if (value === undefined || value === null) return '';
+    return value.toString();
   }
 
-  function countLicensedDescendants(node) {
-    return getAllChildren(node)
-      .reduce((sum, child) => {
-        const isLicensed = child.data && child.data.hasLicense ? 1 : 0;
-        return sum + isLicensed + countLicensedDescendants(child);
-      }, 0);
+  function updateSummary() {
+    if (!summaryElement) return;
+    if (!hasData()) {
+      summaryElement.textContent = 'Upload a CSV or Excel file to begin.';
+      return;
+    }
+    const rowLabel = rows.length === 1 ? 'row' : 'rows';
+    const colLabel = columns.length === 1 ? 'column' : 'columns';
+    summaryElement.textContent = `${rows.length} ${rowLabel} • ${columns.length} ${colLabel}`;
   }
-  
-  // Public API
+
+  function updateEmptyState() {
+    if (!tableWrapper || !emptyStateElement) return;
+    if (!hasData()) {
+      tableWrapper.classList.add('empty');
+      emptyStateElement.style.display = 'flex';
+    } else {
+      tableWrapper.classList.remove('empty');
+      emptyStateElement.style.display = 'none';
+    }
+  }
+
+  function render() {
+    if (!tableHead || !tableBody) return;
+
+    tableHead.innerHTML = '';
+    tableBody.innerHTML = '';
+
+    if (!hasData()) {
+      updateSummary();
+      updateEmptyState();
+      return;
+    }
+
+    const headerRow = document.createElement('tr');
+    columns.forEach(column => {
+      const th = document.createElement('th');
+      th.textContent = column;
+      headerRow.appendChild(th);
+    });
+    tableHead.appendChild(headerRow);
+
+    rows.forEach(row => {
+      const tr = document.createElement('tr');
+      columns.forEach((_, idx) => {
+        const td = document.createElement('td');
+        td.textContent = formatCell(row[idx]);
+        tr.appendChild(td);
+      });
+      tableBody.appendChild(tr);
+    });
+
+    updateSummary();
+    updateEmptyState();
+  }
+
+  function hasData() {
+    return columns.length > 0 && rows.length > 0;
+  }
+
+  function normalizeColumnName(name) {
+    return (name || '')
+      .toString()
+      .replace(/[^a-z0-9]/gi, '')
+      .toLowerCase();
+  }
+
   return {
-    // Initialize the visualization module
     initialize: function() {
-      // Set up event listeners
-      const horizontalSlider = document.getElementById('horizontalSpacing');
-      if (horizontalSlider) {
-        horizontalSlider.addEventListener('input', (e) => {
-          config.horizontalSpacing = parseInt(e.target.value);
-          document.getElementById('horizontalValue').textContent = e.target.value;
-        });
-      }
-      
-      const verticalSlider = document.getElementById('verticalSpacing');
-      if (verticalSlider) {
-        verticalSlider.addEventListener('input', (e) => {
-          config.verticalSpacing = parseFloat(e.target.value);
-          document.getElementById('verticalValue').textContent = e.target.value;
-        });
-      }
-
-      const showStarsCheckbox = document.getElementById('showStars');
-      if (showStarsCheckbox) {
-        config.showEngagementStars = showStarsCheckbox.checked;
-        showStarsCheckbox.addEventListener('change', (e) => {
-          config.showEngagementStars = e.target.checked;
-          if (root) this.update(root);
-        });
-      }
-
-      const dimModeSelect = document.getElementById('dimMode');
-      if (dimModeSelect) {
-        config.dimMode = dimModeSelect.value;
-        dimModeSelect.addEventListener('change', (e) => {
-          config.dimMode = e.target.value;
-          if (root) this.update(root);
-        });
-      }
+      tableElement = document.getElementById('dataTable');
+      tableHead = tableElement ? tableElement.querySelector('thead') : null;
+      tableBody = tableElement ? tableElement.querySelector('tbody') : null;
+      tableWrapper = document.getElementById('tableWrapper');
+      summaryElement = document.getElementById('tableSummary');
+      emptyStateElement = document.getElementById('tableEmptyState');
+      this.clear();
     },
-    
-    // Create the visualization
-    createVisualization: function(hierarchyData, userData, licenses) {
-      if (!hierarchyData) {
-        console.error('No hierarchy data provided');
-        return;
-      }
-      
-      // Reset any existing search or department highlights
-      highlightedDepartment = null;
-      highlightedNodes = null;
-      licenseHighlightActive = false;
-      document.querySelectorAll('.dept-row').forEach(row => row.classList.remove('active'));
-      const searchInput = document.getElementById('searchInput');
-      if (searchInput) searchInput.value = '';
-      const clearBtn = document.getElementById('clearHighlightBtn');
-      if (clearBtn) clearBtn.style.display = 'none';
-      const licenseBtn = document.getElementById('licenseToggleBtn');
-      if (licenseBtn) licenseBtn.classList.remove('active');
 
-      orgData = userData;
-      licensedEmails = licenses;
-
-      // Set up color scales
-      this.setupColorScales();
-      
-      // Get container dimensions
-      const container = document.getElementById('treeContainer');
-      const width = container.clientWidth - config.margin.left - config.margin.right;
-      const height = container.clientHeight - config.margin.top - config.margin.bottom;
-      
-      // Clear previous visualization
-      d3.select('#treeContainer').selectAll('*').remove();
-      
-      // Create SVG
-      svg = d3.select('#treeContainer')
-        .append('svg')
-        .attr('width', container.clientWidth)
-        .attr('height', container.clientHeight);
-      
-      // Create group for zoom
-      g = svg.append('g')
-        .attr('transform', `translate(${config.margin.left},${height / 2})`);
-      
-      // Set up zoom behavior
-      zoom = d3.zoom()
-        .scaleExtent([0.1, 3])
-        .on('zoom', (event) => {
-          g.attr('transform', event.transform);
-        });
-      
-      svg.call(zoom);
-
-      // Hide selected user panel when clicking on empty space
-      svg.on('click', () => {
-        const section = document.getElementById('selectedUserSection');
-        if (section) {
-          section.style.display = 'none';
-          section.innerHTML = '';
-        }
-      });
-      
-      // Create tree layout
-      treemap = d3.tree().size([height, width]);
-      
-      // Create hierarchy
-      root = d3.hierarchy(hierarchyData);
-      root.x0 = height / 2;
-      root.y0 = 0;
-      
-      // Store original positions
-      root.descendants().forEach(d => {
-        d.x0 = d.x;
-        d.y0 = d.y;
-      });
-      
-      // Collapse after the second level initially
-      if (root.children) {
-        root.children.forEach(this.collapse);
-      }
-      currentExpandLevel = 1;
-
-      // Initial render
-      this.update(root);
-
-      // Show controls and panels
-      document.getElementById('legend').style.display = 'block';
-      const selectedSection = document.getElementById('selectedUserSection');
-      if (selectedSection) {
-        selectedSection.style.display = 'none';
-        selectedSection.innerHTML = '';
-      }
-      document.getElementById('statsPanel').style.display = 'block';
-      document.getElementById('bottomControls').style.display = 'flex';
-
-      this.updateLegend();
-      this.updateStatsPanel();
+    clear: function() {
+      columns = [];
+      rows = [];
+      if (tableHead) tableHead.innerHTML = '';
+      if (tableBody) tableBody.innerHTML = '';
+      updateSummary();
+      updateEmptyState();
     },
-    
-    // Setup color scales
-    setupColorScales: function() {
-      const departments = [...new Set(orgData.map(u => u.department))];
-      // Use a color scheme that avoids reds to prevent confusion with license borders
-      const colorPalette = [
-        '#1f77b4', // blue
-        '#2ca02c', // green
-        '#ff7f0e', // orange
-        '#9467bd', // purple
-        '#8c564b', // brown
-        '#e377c2', // pink
-        '#7f7f7f', // gray
-        '#bcbd22', // olive
-        '#17becf', // cyan
-        '#aec7e8', // light blue
-        '#ffbb78', // light orange
-        '#98df8a', // light green
-        '#c5b0d5', // light purple
-        '#c49c94', // light brown
-        '#f7b6d2', // light pink
-        '#c7c7c7', // light gray
-        '#dbdb8d', // light olive
-        '#9edae5'  // light cyan
-      ];
-      
-      departmentColorScale = d3.scaleOrdinal()
-        .domain(departments)
-        .range(colorPalette);
-      
-      levelColorScale = d3.scaleSequential()
-        .domain([0, 5])
-        .interpolator(d3.interpolateBlues);
+
+    loadData: function(newColumns, newRows) {
+      columns = Array.isArray(newColumns)
+        ? newColumns.map((col, idx) => {
+            const label = (col === undefined || col === null || col === '')
+              ? `Column ${idx + 1}`
+              : col.toString();
+            return label;
+          })
+        : [];
+      rows = Array.isArray(newRows) ? newRows.map(normalizeRow) : [];
+      render();
     },
-    
-    // Update the tree
-    update: function(source) {
-      if (!root || !treemap) return;
-      
-      // Compute the new tree layout
-      const treeData = treemap(root);
-      const nodes = treeData.descendants();
-      const links = treeData.links();
-      
-      // Normalize for fixed-depth and apply spacing
-      nodes.forEach(d => {
-        d.y = d.depth * config.horizontalSpacing;
-        d.x = d.x * config.verticalSpacing;
-      });
-      
-      // -------------------- NODES --------------------
-      const node = g.selectAll('g.node')
-        .data(nodes, d => d.id || (d.id = ++i));
-      
-      // Enter new nodes at the parent's previous position
-      const nodeEnter = node.enter().append('g')
-        .attr('class', 'node')
-        .attr('transform', d => `translate(${source.y0 || 0},${source.x0 || 0})`)
-        .style('display', d => this.getNodeDisplay(d))
-        .on('click', (event, d) => {
-          // Prevent background click handler from firing when selecting a node
-          event.stopPropagation();
-          this.click(event, d);
-        })
-        .on('mouseover', (event, d) => this.showTooltip(event, d))
-        .on('mouseout', () => this.hideTooltip());
-      
-      // Add circles for nodes
-      nodeEnter.append('circle')
-        .attr('r', 1e-6)
-        .style('fill', d => this.getNodeColor(d))
-        .style('stroke', d => this.getNodeStroke(d))
-        .style('opacity', d => this.getNodeOpacity(d));
-      
-      // Add labels for nodes - include star rating if available
-      nodeEnter.append('text')
-        .attr('dy', '.35em')
-        .attr('x', d => d.children || d._children ? -13 : 13)
-        .attr('text-anchor', d => d.children || d._children ? 'end' : 'start')
-        .text(d => this.getNodeLabel(d))
-        .style('fill-opacity', 1e-6);
-      
-      // Add title (job title) as second line
-      nodeEnter.append('text')
-        .attr('class', 'title')
-        .attr('dy', '1.5em')
-        .attr('x', d => d.children || d._children ? -13 : 13)
-        .attr('text-anchor', d => d.children || d._children ? 'end' : 'start')
-        .text(d => d.data.title || '')
-        .style('fill-opacity', 1e-6);
-      
-      // UPDATE
-      const nodeUpdate = nodeEnter.merge(node);
 
-      // Transition to the proper position for the node
-      nodeUpdate.transition()
-        .duration(config.duration)
-        .attr('transform', d => `translate(${d.y},${d.x})`);
+    hasData,
 
-      // Disable interactions for dimmed nodes
-      nodeUpdate
-        .style('display', d => this.getNodeDisplay(d))
-        .style('pointer-events', d =>
-          !highlightedNodes || highlightedNodes.has(d.data.email) ? 'all' : 'none')
-        .style('cursor', d =>
-          !highlightedNodes || highlightedNodes.has(d.data.email) ? 'pointer' : 'default');
-      
-      // Update the node attributes and style
-      nodeUpdate.select('circle')
-        .attr('r', config.nodeRadius)
-        .style('fill', d => this.getNodeColor(d))
-        .style('stroke', d => this.getNodeStroke(d))
-        .style('opacity', d => this.getNodeOpacity(d));
-      
-      nodeUpdate.select('text')
-        .text(d => this.getNodeLabel(d))
-        .style('fill-opacity', d => this.getNodeOpacity(d));
-      
-      nodeUpdate.select('text.title')
-        .style('fill-opacity', d => this.getNodeOpacity(d) * 0.7);
-      
-      // EXIT
-      const nodeExit = node.exit().transition()
-        .duration(config.duration)
-        .attr('transform', d => `translate(${source.y},${source.x})`)
-        .remove();
-      
-      nodeExit.select('circle')
-        .attr('r', 1e-6);
-      
-      nodeExit.select('text')
-        .style('fill-opacity', 1e-6);
-      
-      // -------------------- LINKS --------------------
-      const link = g.selectAll('path.link')
-        .data(links, d => d.target.id);
-      
-      // Enter new links at the parent's previous position
-      const linkEnter = link.enter().insert('path', 'g')
-        .attr('class', 'link')
-        .style('display', d => this.getLinkDisplay(d))
-        .style('opacity', d => this.getLinkOpacity(d))
-        .attr('d', d => {
-          const o = { x: source.x0 || 0, y: source.y0 || 0 };
-          return this.diagonal(o, o);
-        });
-
-      // UPDATE
-      const linkUpdate = linkEnter.merge(link);
-
-      // Transition back to the parent element position
-      linkUpdate
-        .style('display', d => this.getLinkDisplay(d))
-        .transition()
-        .duration(config.duration)
-        .attr('d', d => this.diagonal(d.source, d.target))
-        .style('opacity', d => this.getLinkOpacity(d));
-      
-      // EXIT
-      link.exit().transition()
-        .duration(config.duration)
-        .attr('d', d => {
-          const o = { x: source.x, y: source.y };
-          return this.diagonal(o, o);
-        })
-        .remove();
-      
-      // Store the old positions for transition
-      nodes.forEach(d => {
-        d.x0 = d.x;
-        d.y0 = d.y;
-      });
-
-      // Refresh statistics to reflect current view
-      this.updateStatsPanel();
+    getRowCount: function() {
+      return rows.length;
     },
-    
-    // Creates a curved (diagonal) path from parent to child nodes
-    diagonal: function(source, target) {
-      // Handle both cases: when called with link object or separate source/target
-      const s = source.source ? source.source : source;
-      const d = source.target ? source.target : target;
-      
-      // Safety check for valid coordinates
-      if (!s || !d || 
-          s.y === undefined || s.x === undefined || 
-          d.y === undefined || d.x === undefined) {
+
+    getColumnCount: function() {
+      return columns.length;
+    },
+
+    getColumns: function() {
+      return columns.slice();
+    },
+
+    getRows: function() {
+      return rows.map(row => row.slice());
+    },
+
+    getCellValue: function(rowIndex, columnIndex) {
+      if (!rows[rowIndex] || columnIndex < 0 || columnIndex >= columns.length) {
         return '';
       }
-      
-      return `M ${s.y} ${s.x}
-              C ${(s.y + d.y) / 2} ${s.x},
-                ${(s.y + d.y) / 2} ${d.x},
-                ${d.y} ${d.x}`;
-    },
-    
-    // Toggle children on click
-    click: function(event, d) {
-      if (d.children) {
-        d._children = d.children;
-        d.children = null;
-      } else {
-        d.children = d._children;
-        d._children = null;
-      }
-      this.update(d);
-      this.updateSelectedUser(d);
-    },
-    
-    // Collapse node
-    collapse: function(d) {
-      if (d.children) {
-        d._children = d.children;
-        d._children.forEach(OrgChart.collapse);
-        d.children = null;
-      }
+      return formatCell(rows[rowIndex][columnIndex]);
     },
 
-    // Expand next tier of nodes
-    expandOneLevel: function() {
-      if (!root) return;
-
-      let expanded = false;
-
-      function traverse(node, depth) {
-        if (depth <= currentExpandLevel && node._children) {
-          node.children = node._children;
-          node._children = null;
-          expanded = true;
-        }
-
-        const children = node.children ? node.children.slice() : [];
-        const hidden = node._children ? node._children.slice() : [];
-        [...children, ...hidden].forEach(child => traverse(child, depth + 1));
+    ensureColumn: function(columnName, preferredIndex) {
+      const normalized = columnName.toLowerCase();
+      let existingIndex = columns.findIndex(col => col.toLowerCase() === normalized);
+      if (existingIndex !== -1) {
+        return existingIndex;
       }
 
-      traverse(root, 0);
+      const targetIndex = Math.max(0, Math.min(
+        typeof preferredIndex === 'number' ? preferredIndex : columns.length,
+        columns.length
+      ));
 
-      if (expanded) {
-        currentExpandLevel++;
-        this.update(root);
-      }
-    },
-
-    // Collapse the deepest expanded tier
-    collapseOneLevel: function() {
-      if (!root) return;
-
-      const nodes = root.descendants();
-      let deepestWithChildren = -1;
-
-      nodes.forEach((node) => {
-        if (node.children && node.children.length > 0) {
-          deepestWithChildren = Math.max(deepestWithChildren, node.depth);
-        }
+      columns.splice(targetIndex, 0, columnName);
+      rows.forEach(row => {
+        row.splice(targetIndex, 0, '');
       });
+      return targetIndex;
+    },
 
-      if (deepestWithChildren < 0) return;
-
-      let collapsed = false;
-      nodes.forEach((node) => {
-        if (node.depth === deepestWithChildren && node.children && node.children.length > 0) {
-          this.collapse(node);
-          collapsed = true;
-        }
+    setColumnValues: function(columnIndex, values) {
+      rows.forEach((row, idx) => {
+        row[columnIndex] = formatCell(values[idx]);
       });
-
-      if (!collapsed) return;
-
-      let newDeepest = -1;
-      root.descendants().forEach((node) => {
-        if (node.children && node.children.length > 0) {
-          newDeepest = Math.max(newDeepest, node.depth);
-        }
-      });
-
-      currentExpandLevel = Math.max(0, newDeepest + 1);
-      this.update(root);
+      render();
     },
 
-    // Expand all nodes
-    expandAll: function() {
-      if (!root) return;
-
-      function expand(d) {
-        if (d._children) {
-          d.children = d._children;
-          d._children = null;
-        }
-        if (d.children) {
-          d.children.forEach(expand);
-        }
-      }
-
-      expand(root);
-      currentExpandLevel = root.height + 1;
-      this.update(root);
-    },
-
-    // Collapse all nodes
-    collapseAll: function() {
-      if (!root) return;
-
-      if (root.children) {
-        root.children.forEach(this.collapse);
-      }
-      currentExpandLevel = 1;
-      this.update(root);
-    },
-    
-    // Reset view to center
-    resetView: function() {
-      if (!svg || !root) return;
-
-      const nodes = root.descendants();
-      let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-      nodes.forEach(d => {
-        minX = Math.min(minX, d.x);
-        maxX = Math.max(maxX, d.x);
-        minY = Math.min(minY, d.y);
-        maxY = Math.max(maxY, d.y);
-      });
-
-      const container = document.getElementById('treeContainer');
-      const width = container.clientWidth - config.margin.left - config.margin.right;
-      const height = container.clientHeight - config.margin.top - config.margin.bottom;
-
-      const dx = maxX - minX;
-      const dy = maxY - minY;
-      const scale = Math.min(width / (dy || width), height / (dx || height));
-      const tx = -minY * scale + (width - dy * scale) / 2 + config.margin.left;
-      const ty = -minX * scale + (height - dx * scale) / 2 + config.margin.top;
-
-      svg.transition()
-        .duration(750)
-        .call(zoom.transform, d3.zoomIdentity.translate(tx, ty).scale(scale));
-    },
-
-    // Download current graph data as CSV
-    downloadCSV: function() {
-      if (!orgData || orgData.length === 0) return;
-
-      // Determine which users to export
-      let dataToExport = orgData;
-      if (highlightedNodes && highlightedNodes.size > 0) {
-        dataToExport = orgData.filter(u => highlightedNodes.has(u.email));
-      }
-
-      const header = ['Name', 'Title', 'Department', 'Location', 'Email', 'License', 'AI Usage'];
-      const rows = dataToExport.map(u => {
-        const rating = u.aiEngagement !== undefined ? GraphAPI.getStarRating(u.aiEngagement) : null;
-        const daily = u.aiEngagement !== undefined ? Math.round(u.aiEngagement * 3) : '';
-        const aiUsage = rating ? `${rating.label} (~${daily}/day)` : '';
-        return [
-          u.name || '',
-          u.title || '',
-          u.department || '',
-          u.location || '',
-          u.email || '',
-          u.hasLicense ? 'Yes' : 'No',
-          aiUsage
-        ];
-      });
-
-      const csv = [header, ...rows]
-        .map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(','))
-        .join('\n');
-
-      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(blob);
-      link.download = 'org-data.csv';
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    },
-
-    // Update spacing
-    updateSpacing: function(type, value) {
-      if (type === 'horizontal') {
-        config.horizontalSpacing = parseInt(value);
-        document.getElementById('horizontalValue').textContent = value;
-      } else if (type === 'vertical') {
-        config.verticalSpacing = parseFloat(value);
-        document.getElementById('verticalValue').textContent = value;
-      }
-      
-      if (root) {
-        this.update(root);
-      }
-    },
-    
-    // Update visualization with new color scheme
-    updateVisualization: function() {
-      if (root) {
-        this.update(root);
-        this.updateLegend();
-      }
-    },
-    
-    // Highlight department nodes
-    highlightDepartment: function(department) {
-      // If clicking the same department, clear the highlight
-      if (highlightedDepartment === department) {
-        this.clearHighlight();
-      } else {
-        highlightedDepartment = department;
-        highlightedNodes = new Set(orgData
-          .filter(u => u.department === department)
-          .map(u => u.email));
-        highlightedNodes = highlightedNodes.size > 0 ? highlightedNodes : null;
-        const input = document.getElementById('searchInput');
-        if (input) input.value = '';
-        const searchClearBtn = document.getElementById('clearSearchBtn');
-        if (searchClearBtn) searchClearBtn.style.display = 'none';
-        licenseHighlightActive = false;
-        const licenseBtn = document.getElementById('licenseToggleBtn');
-        if (licenseBtn) licenseBtn.classList.remove('active');
-
-        // Update active class on rows
-        document.querySelectorAll('.dept-row').forEach(row => {
-          if (row.dataset.department === department) {
-            row.classList.add('active');
-          } else {
-            row.classList.remove('active');
-          }
-        });
-
-        // Show clear highlight button
-        const clearBtn = document.getElementById('clearHighlightBtn');
-        if (clearBtn) {
-          clearBtn.style.display = 'flex';
-        }
-      }
-
-      // Update the visualization
-      if (root) {
-        this.update(root);
-      }
-    },
-
-    // Toggle highlight of licensed users
-    toggleLicenseHighlight: function() {
-      if (licenseHighlightActive) {
-        this.clearHighlight();
-      } else {
-        highlightedDepartment = null;
-        highlightedNodes = new Set(orgData.filter(u => u.hasLicense).map(u => u.email));
-        highlightedNodes = highlightedNodes.size > 0 ? highlightedNodes : null;
-        licenseHighlightActive = true;
-        document.querySelectorAll('.dept-row').forEach(row => row.classList.remove('active'));
-        const input = document.getElementById('searchInput');
-        if (input) input.value = '';
-        const clearBtn = document.getElementById('clearHighlightBtn');
-        if (clearBtn) clearBtn.style.display = 'flex';
-        const searchClearBtn = document.getElementById('clearSearchBtn');
-        if (searchClearBtn) searchClearBtn.style.display = 'none';
-        const licenseBtn = document.getElementById('licenseToggleBtn');
-        if (licenseBtn) licenseBtn.classList.add('active');
-        if (root) this.update(root);
-      }
-    },
-
-    // Search by name or title
-    searchByNameTitle: function() {
-      const input = document.getElementById('searchInput');
-      if (!input) return;
-      const raw = input.value.trim().toLowerCase();
-      if (!raw) {
-        this.clearHighlight();
+    applyFieldValues: function(fieldLabels, valueLookup, options = {}) {
+      if (!Array.isArray(fieldLabels) || fieldLabels.length === 0) {
         return;
       }
+      const mode = options.mode === 'index' ? 'index' : 'end';
+      let insertionIndex = mode === 'index'
+        ? Math.max(0, Math.min(options.index ?? columns.length, columns.length))
+        : columns.length;
 
-      // Split on quoted phrases or individual words
-      const terms = raw.match(/"[^"]+"|\S+/g) || [];
-
-      highlightedDepartment = null;
-      highlightedNodes = new Set(orgData.filter(u => {
-        const name = (u.name || '').toLowerCase();
-        const title = (u.title || '').toLowerCase();
-        return terms.some(t => {
-          const token = t.replace(/^"|"$/g, '');
-          return name.includes(token) || title.includes(token);
+      fieldLabels.forEach(label => {
+        const targetIndex = this.ensureColumn(label, insertionIndex);
+        const values = valueLookup[label] || [];
+        rows.forEach((row, rowIdx) => {
+          row[targetIndex] = formatCell(values[rowIdx]);
         });
-      }).map(u => u.email));
-
-      highlightedNodes = highlightedNodes.size > 0 ? highlightedNodes : null;
-      licenseHighlightActive = false;
-      const licenseBtn = document.getElementById('licenseToggleBtn');
-      if (licenseBtn) licenseBtn.classList.remove('active');
-
-      // Remove active class from department rows
-      document.querySelectorAll('.dept-row').forEach(row => row.classList.remove('active'));
-
-      // Show clear search button if we found matches
-      const clearHighlightBtn = document.getElementById('clearHighlightBtn');
-      if (clearHighlightBtn) {
-        clearHighlightBtn.style.display = 'none';
-      }
-      const clearSearchBtn = document.getElementById('clearSearchBtn');
-      if (clearSearchBtn) {
-        clearSearchBtn.style.display = highlightedNodes && highlightedNodes.size > 0 ? 'flex' : 'none';
-      }
-
-      if (root) {
-        this.update(root);
-      }
-    },
-
-    // Clear highlight (department or search)
-    clearHighlight: function() {
-      highlightedDepartment = null;
-      highlightedNodes = null;
-      licenseHighlightActive = false;
-
-      // Remove active class from all rows
-      document.querySelectorAll('.dept-row').forEach(row => {
-        row.classList.remove('active');
+        if (mode === 'index' && targetIndex >= insertionIndex) {
+          insertionIndex = targetIndex + 1;
+        }
       });
 
-      // Clear search input
-      const input = document.getElementById('searchInput');
-      if (input) input.value = '';
-
-      // Hide clear buttons
-      const clearHighlightBtn = document.getElementById('clearHighlightBtn');
-      if (clearHighlightBtn) {
-        clearHighlightBtn.style.display = 'none';
-      }
-      const clearSearchBtn = document.getElementById('clearSearchBtn');
-      if (clearSearchBtn) {
-        clearSearchBtn.style.display = 'none';
-      }
-      const licenseBtn = document.getElementById('licenseToggleBtn');
-      if (licenseBtn) licenseBtn.classList.remove('active');
-
-      // Update the visualization
-      if (root) {
-        this.update(root);
-      }
+      render();
     },
 
-    // Get node opacity based on highlight
-    getNodeOpacity: function(d) {
-      if (!highlightedNodes) {
-        return 1;
-      }
-      if (highlightedNodes.has(d.data.email)) {
-        return 1;
+    findEmailColumn: function() {
+      if (!columns.length) return -1;
+      const preferredMatches = ['email', 'mail', 'userprincipalname', 'signinname', 'upn'];
+      const normalizedColumns = columns.map(normalizeColumnName);
+
+      for (const match of preferredMatches) {
+        const index = normalizedColumns.findIndex(col => col.includes(match));
+        if (index !== -1) return index;
       }
 
-      switch (config.dimMode) {
-        case 'transparent':
-        case 'hidden':
-          return 0;
-        case 'dim':
-        default:
-          return 0.2;
-      }
+      return normalizedColumns.findIndex(col => /mail|email/.test(col));
     },
 
-    // Get link opacity based on highlight
-    getLinkOpacity: function(d) {
-      if (!highlightedNodes) {
-        return 1;
-      }
-      // Show link if either source or target is in highlighted set
-      const isHighlighted = (highlightedNodes.has(d.source.data.email) ||
-              highlightedNodes.has(d.target.data.email));
-
-      if (isHighlighted) {
-        return 0.6;
-      }
-
-      switch (config.dimMode) {
-        case 'transparent':
-        case 'hidden':
-          return 0;
-        case 'dim':
-        default:
-          return 0.1;
-      }
-    },
-
-    // Get node display based on highlight and dim mode
-    getNodeDisplay: function(d) {
-      if (!highlightedNodes || config.dimMode !== 'hidden') {
-        return null;
-      }
-
-      return highlightedNodes.has(d.data.email) ? null : 'none';
-    },
-
-    // Get link display based on highlight and dim mode
-    getLinkDisplay: function(d) {
-      if (!highlightedNodes || config.dimMode !== 'hidden') {
-        return null;
-      }
-
-      const isHighlighted = highlightedNodes.has(d.source.data.email) ||
-        highlightedNodes.has(d.target.data.email);
-
-      return isHighlighted ? null : 'none';
-    },
-
-    // Get node label with optional engagement stars
-    getNodeLabel: function(d) {
-      const name = d.data.name || 'Unknown';
-      if (config.showEngagementStars && d.data.aiEngagement !== undefined && d.data.aiEngagement > 0) {
-        const rating = GraphAPI.getStarRating(d.data.aiEngagement);
-        return `${name} ${rating.stars}`;
-      }
-      return name;
-    },
-
-    // Get node color based on current color scheme
-    getNodeColor: function(d) {
-      const colorBy = document.getElementById('colorBy').value;
-      
-      if (colorBy === 'license') {
-        return d.data.hasLicense ? '#00a854' : '#f0f0f0';
-      } else if (colorBy === 'level') {
-        return levelColorScale(Math.min(d.depth, 5));
-      } else { // department
-        return departmentColorScale(d.data.department || 'Unknown');
-      }
-    },
-    
-    // Get node stroke color
-    getNodeStroke: function(d) {
-      // Red border for no license, green for has license
-      if (d.data.hasLicense) {
-        return '#00a854'; // Green for licensed users
-      }
-      return '#dc3545'; // Red for unlicensed users
-    },
-    
-    // Show tooltip
-    showTooltip: function(event, d) {
-      // Don't show tooltip for dimmed nodes when highlighting is active
-      if (highlightedNodes && !highlightedNodes.has(d.data.email)) {
-        return;
-      }
-
-      const tooltip = document.getElementById('tooltip');
-      const licenseText = d.data.hasLicense ?
-        '<span style="color: #00a854; font-weight: bold;">✔ Has ChatGPT License</span>' :
-        '<span style="color: #dc3545; font-weight: bold;">✗ No ChatGPT License</span>';
-      
-      // Calculate AI engagement display
-      let engagementText = '';
-      if (d.data.aiEngagement !== undefined) {
-          const rating = GraphAPI.getStarRating(d.data.aiEngagement);
-          const dailyEngagements = Math.round(d.data.aiEngagement * 3);
-          engagementText = `
-            <div style="margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid #ddd;">
-              <strong>AI Engagement:</strong> ${rating.stars}<br>
-              <span style="color: var(--text-light); font-size: 0.85rem;">
-                ${rating.label} (~${dailyEngagements} engagements/day)
-              </span>
-            </div>
-          `;
-        }
-
-      const totalReports = countDescendants(d);
-      const licensedReports = countLicensedDescendants(d);
-      const licensePercent = totalReports > 0
-        ? Number(((licensedReports / totalReports) * 100).toFixed(1))
-        : 0;
-
-      tooltip.innerHTML = `
-        <strong>${d.data.name || 'Unknown'}</strong><br>
-        ${d.data.title ? d.data.title + '<br>' : ''}
-        ${d.data.department || 'No department'}<br>
-        ${d.data.location ? d.data.location + '<br>' : ''}
-        ${d.data.email ? d.data.email + '<br>' : ''}
-        Total Reports: ${totalReports}<br>
-        Licensed Users: ${licensedReports} (${licensePercent}%)<br>
-        <div style="margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid #ddd;">
-          ${licenseText}
-        </div>
-        ${engagementText}
-      `;
-      
-      tooltip.style.left = (event.pageX + 10) + 'px';
-      tooltip.style.top = (event.pageY - 10) + 'px';
-      tooltip.classList.add('visible');
-    },
-    
-    // Hide tooltip
-    hideTooltip: function() {
-      document.getElementById('tooltip').classList.remove('visible');
-    },
-
-    // Update selected user panel
-    updateSelectedUser: function(d) {
-      const section = document.getElementById('selectedUserSection');
-      if (!section) return;
-
-      const totalReports = countDescendants(d);
-      const licensedReports = countLicensedDescendants(d);
-      const licensePercent = totalReports > 0
-        ? Number(((licensedReports / totalReports) * 100).toFixed(1))
-        : 0;
-      const emailHtml = d.data.email ? `
-        <div class="selected-user-email">
-          <span>${d.data.email}</span>
-          <button class="copy-btn">Copy</button>
-        </div>` : '';
-
-      section.innerHTML = `
-        <h4>Selected User</h4>
-        <div><strong>${d.data.name || 'Unknown'}</strong></div>
-        ${d.data.title ? `<div>${d.data.title}</div>` : ''}
-        <div>${d.data.department || 'No department'}</div>
-        ${d.data.location ? `<div>${d.data.location}</div>` : ''}
-        ${emailHtml}
-        <div>Total Reports: ${totalReports}</div>
-        <div>Licensed Users: ${licensedReports} (${licensePercent}%)</div>
-      `;
-      section.style.display = 'block';
-
-      if (d.data.email) {
-        const btn = section.querySelector('.copy-btn');
-        if (btn) {
-          btn.addEventListener('click', () => navigator.clipboard.writeText(d.data.email));
-        }
-      }
-    },
-    
-    // Update legend based on color scheme
-    updateLegend: function() {
-      const legendContent = document.getElementById('legendContent');
-      const colorBy = document.getElementById('colorBy').value;
-
-      let html = '<h4>Legend</h4>';
-      
-      // Always show license border legend
-      html += `
-        <div style="margin-bottom: 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);">
-          <strong>License Status (Border)</strong>
-          <div class="legend-item">
-            <div class="legend-color" style="background: white; border: 3px solid #00a854;"></div>
-            <span>Has ChatGPT License</span>
-          </div>
-          <div class="legend-item">
-            <div class="legend-color" style="background: white; border: 3px solid #dc3545;"></div>
-            <span>No License</span>
-          </div>
-        </div>
-      `;
-      
-      // Add color-specific legend
-      html += '<strong>Node Color</strong>';
-      
-      if (colorBy === 'license') {
-        html += `
-          <div class="legend-item">
-            <div class="legend-color" style="background: #00a854;"></div>
-            <span>Has License (Fill)</span>
-          </div>
-          <div class="legend-item">
-            <div class="legend-color" style="background: #f0f0f0;"></div>
-            <span>No License (Fill)</span>
-          </div>
-        `;
-      } else if (colorBy === 'level') {
-        for (let i = 0; i <= 4; i++) {
-          html += `
-            <div class="legend-item">
-              <div class="legend-color" style="background: ${levelColorScale(i)};"></div>
-              <span>Level ${i}</span>
-            </div>
-          `;
-        }
-      } else { // department
-        const departments = [...new Set(orgData.map(u => u.department))].slice(0, 10);
-        departments.forEach(dept => {
-          html += `
-            <div class="legend-item">
-              <div class="legend-color" style="background: ${departmentColorScale(dept)};"></div>
-              <span>${dept}</span>
-            </div>
-          `;
-        });
-        if (departments.length < [...new Set(orgData.map(u => u.department))].length) {
-          html += '<div class="legend-item"><small>...and more</small></div>';
-        }
-      }
-      
-      legendContent.innerHTML = html;
-    },
-    
-    // Update statistics panel
-    updateStatsPanel: function() {
-      const stats = document.getElementById('statsPanel');
-      const totalUsers = orgData.length;
-      const licensed = orgData.filter(u => u.hasLicense).length;
-      const licensedPercent = totalUsers > 0
-        ? Math.round((licensed / totalUsers) * 100)
-        : 0;
-      const departments = [...new Set(orgData.map(u => u.department))].length;
-      const visibleNodes = root ? root.descendants() : [];
-      const visibleLicensed = visibleNodes.filter(d => d.data.hasLicense).length;
-      const visibleLicensedPercent = visibleNodes.length > 0
-        ? Math.round((visibleLicensed / visibleNodes.length) * 100)
-        : 0;
-      const highlightedVisibleNodes = highlightedNodes
-        ? visibleNodes.filter(d => highlightedNodes.has(d.data.email))
-        : [];
-      const isolatedCount = highlightedVisibleNodes.length;
-      const isolatedLicensed = highlightedVisibleNodes.filter(d => d.data.hasLicense).length;
-      const isolatedLicensedPercent = isolatedCount > 0
-        ? Math.round((isolatedLicensed / isolatedCount) * 100)
-        : 0;
-
-      stats.innerHTML = `
-        <div class="stat-item">
-          <span class="stat-label">Total Users:</span>
-          <span class="stat-value">${totalUsers}</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">Licensed:</span>
-          <span class="stat-value">${licensed} (${licensedPercent}%)</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">Departments:</span>
-          <span class="stat-value">${departments}</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">Isolated Users:</span>
-          <span class="stat-value">${isolatedCount}</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">Isolated Licensed Users:</span>
-          <span class="stat-value">${isolatedLicensed} (${isolatedLicensedPercent}%)</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">Visible Users:</span>
-          <span class="stat-value">${visibleNodes.length}</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">Visible Licensed Users:</span>
-          <span class="stat-value">${visibleLicensed} (${visibleLicensedPercent}%)</span>
-        </div>
-      `;
+    getDataForExport: function() {
+      return {
+        columns: this.getColumns(),
+        rows: this.getRows()
+      };
     }
   };
 })();
-
-// Expose OrgChart to global scope for inline event handlers
-window.OrgChart = OrgChart;


### PR DESCRIPTION
## Summary
- redesign the layout to keep the token panel and add CSV/Excel upload plus paste support for email lists
- replace the org chart canvas with a responsive data table that shows uploaded rows and supports configurable append locations
- implement Microsoft Graph profile fetching with selectable fields, progress feedback, and CSV/XLSX export of the enriched data

## Testing
- no automated tests were run (project does not include test scripts)


------
https://chatgpt.com/codex/tasks/task_b_68cb4bf0c2e08328b408899026bb5043