### PR TITLE
Add progress counter to profile retrieval overlay

### DIFF
--- a/graph-api.js
+++ b/graph-api.js
@@ -337,7 +337,7 @@ const GraphAPI = (function() {
       return;
     }
 
-    showLoading('Retrieving Microsoft 365 profiles...');
+    showLoading(`Retrieving Microsoft 365 profiles (0 of ${rowCount})...`);
 
     const fieldLabels = selectedFields.map(field => {
       const definition = fieldDefinitions.find(item => item.key === field);
@@ -359,7 +359,9 @@ const GraphAPI = (function() {
           continue;
         }
 
-        updateStatus('fetchStatus', `Fetching profile ${index + 1} of ${rowCount} (${email})...`, 'info');
+        const currentPosition = index + 1;
+        showLoading(`Retrieving Microsoft 365 profiles (${currentPosition} of ${rowCount})...`);
+        updateStatus('fetchStatus', `Fetching profile ${currentPosition} of ${rowCount} (${email})...`, 'info');
 
         try {
           const profile = await fetchUserProfile(email, selectedFields);


### PR DESCRIPTION
## Summary
- display the number of processed profiles in the loading overlay while fetching Microsoft 365 profiles
- keep the status text in sync with the currently processed profile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cb5cd8d3c483288462e38df8c719d9