### PR TITLE
Normalize Graph lookups to sign-in domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
               <div class="form-group">
                 <label for="graphToken">Access Token:</label>
                 <textarea id="graphToken" placeholder="Paste your Microsoft Graph access token here..."></textarea>
+                <span class="form-hint" id="detectedDomainHint">Detected sign-in domain: not detected yet.</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- detect the signed-in domain from the pasted Microsoft Graph access token and show it in the UI
- try Microsoft Graph profile lookups with both the original email and the login-domain variant so mixed-domain users resolve
- surface clearer warning details listing the specific lookup attempts that failed

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68cb6007a8108328aa3d98df9b6e83b0