### PR TITLE
Fix table vertical scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,7 @@ body {
 .main-content {
   display: flex;
   flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -682,6 +683,7 @@ input[type="checkbox"] {
   background: var(--bg);
   display: flex;
   flex-direction: column;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -689,6 +691,7 @@ input[type="checkbox"] {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
   padding: 1.5rem;
   gap: 1rem;
 }


### PR DESCRIPTION
## Summary
- allow the main flex containers around the data table to shrink within the viewport
- add `min-height: 0` so the table wrapper can display its vertical scrollbar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cb62a896b88328a96f646768e7d345