### PR TITLE
Ensure profile domain lookup preserves original email column

### DIFF
--- a/graph-api.js
+++ b/graph-api.js
@@ -411,10 +411,20 @@ const GraphAPI = (function() {
 
     showLoading(`Retrieving Microsoft 365 profiles (0 of ${rowCount})...`);
 
-    const fieldLabels = selectedFields.map(field => {
-      const definition = fieldDefinitions.find(item => item.key === field);
-      return definition ? definition.label : field;
+    const tableColumns = DataTable.getColumns();
+    const emailColumnName = tableColumns[emailColumnIndex] || '';
+    const normalizedEmailColumnName = emailColumnName.trim().toLowerCase();
+
+    const fieldLabelMap = selectedFields.map(fieldKey => {
+      const definition = fieldDefinitions.find(item => item.key === fieldKey);
+      const baseLabel = definition ? definition.label : fieldKey;
+      if (baseLabel && baseLabel.trim().toLowerCase() === normalizedEmailColumnName) {
+        return { key: fieldKey, label: `${baseLabel} (Graph)` };
+      }
+      return { key: fieldKey, label: baseLabel };
     });
+
+    const fieldLabels = fieldLabelMap.map(item => item.label);
 
     const valuesByField = fieldLabels.reduce((acc, label) => {
       acc[label] = new Array(rowCount).fill('');
@@ -467,10 +477,8 @@ const GraphAPI = (function() {
             continue;
           }
 
-          selectedFields.forEach(fieldKey => {
-            const definition = fieldDefinitions.find(item => item.key === fieldKey);
-            const label = definition ? definition.label : fieldKey;
-            valuesByField[label][index] = formatFieldValue(fieldKey, profile[fieldKey]);
+          fieldLabelMap.forEach(({ key, label }) => {
+            valuesByField[label][index] = formatFieldValue(key, profile[key]);
           });
         } catch (error) {
           errors.push(`${email}: ${error.message}`);


### PR DESCRIPTION
## Summary
- adjust Graph field label mapping so appended data avoids overwriting the lookup email column
- use the derived label map when filling fetched profile values

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68cb658280308328b752985fb91fd7b3